### PR TITLE
Some improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,7 @@ deploy:
   local-dir: docs
   on:
     condition: "$TRAVIS_EVENT_TYPE != cron"
+
+matrix:
+  allow_failures:
+    - crystal: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ before_script:
 
 script:
   # Run specs on their own to isolate scope of each spec.
-  - crystal spec spec/athena_spec.cr --warnings all
-  - crystal spec spec/cli --warnings all
-  - crystal spec spec/config --warnings all
-  - crystal spec spec/dependency_injection --warnings all
-  - crystal spec spec/routing --warnings all
+  - crystal spec spec/athena_spec.cr --order random
+  - crystal spec spec/cli --order random
+  - crystal spec spec/config --order random
+  - crystal spec spec/dependency_injection --order random
+  - crystal spec spec/routing --order random
 
 after_success:
   - crystal docs

--- a/shard.yml
+++ b/shard.yml
@@ -8,7 +8,7 @@ version: 0.7.0
 authors:
   - Blacksmoke16 <Blacksmoke16@eve.tools>
 
-crystal: 0.28.0
+crystal: 0.32.0
 
 license: MIT
 

--- a/shard.yml
+++ b/shard.yml
@@ -35,5 +35,5 @@ dependencies:
 
 development_dependencies:
   ameba:
-    github: veelenga/ameba
+    github: crystal-ameba/ameba
     version: ~> 0.10.0

--- a/spec/dependency_injection/compiler/private_service.cr
+++ b/spec/dependency_injection/compiler/private_service.cr
@@ -1,0 +1,8 @@
+require "../dependency_injection_spec_helper"
+
+@[Athena::DI::Register]
+class Store < Athena::DI::ClassService
+  property name : String = "Jim"
+end
+
+ADI::ServiceContainer.new.store

--- a/spec/dependency_injection/compiler_spec.cr
+++ b/spec/dependency_injection/compiler_spec.cr
@@ -1,0 +1,11 @@
+require "./dependency_injection_spec_helper"
+
+describe Athena::DI do
+  describe Athena::DI::ServiceContainer do
+    describe "when trying to access a private service directly" do
+      it "should not compile" do
+        assert_error "dependency_injection/compiler/private_service.cr", "private method 'store' called for Athena::DI::ServiceContainer"
+      end
+    end
+  end
+end

--- a/spec/dependency_injection/service_container_spec.cr
+++ b/spec/dependency_injection/service_container_spec.cr
@@ -102,20 +102,6 @@ end
 
 describe Athena::DI::ServiceContainer do
   describe "#get" do
-    describe "by type and name" do
-      describe "when the service exists" do
-        it "should return the service with the given name" do
-          CONTAINER.get("fake_service").should be_a FakeService
-        end
-      end
-
-      describe "when the service does not exist" do
-        it "should throw an exception" do
-          expect_raises Exception, "No service with the name 'foobar' has been registered." { CONTAINER.get "foobar" }
-        end
-      end
-    end
-
     describe "by type" do
       it "should return an array of services with that type" do
         services = CONTAINER.get FakeServices

--- a/spec/dependency_injection/service_container_spec.cr
+++ b/spec/dependency_injection/service_container_spec.cr
@@ -39,7 +39,7 @@ class PartnerParamConverter
   def initialize(@manager : PartnerManager); end
 end
 
-@[Athena::DI::Register]
+@[Athena::DI::Register(public: true)]
 class Store < Athena::DI::ClassService
   property name : String = "Jim"
 end
@@ -108,6 +108,12 @@ describe Athena::DI::ServiceContainer do
         services.size.should eq 2
         services[0].should be_a FakeService
         services[1].should be_a CustomFooFakeService
+      end
+    end
+
+    describe "by name" do
+      it "should allow getting public services directly" do
+        CONTAINER.store.name.should eq "Jim"
       end
     end
   end

--- a/spec/routing/callback_spec.cr
+++ b/spec/routing/callback_spec.cr
@@ -1,124 +1,124 @@
 require "./routing_spec_helper"
 
-do_with_config do |client|
-  describe Athena::Routing::Callback do
-    describe "user endpoint" do
-      it "should set the correct headers" do
-        headers = client.get("/callback/users").headers
-        headers.includes_word?("X-RESPONSE-ALL-ROUTES", "true").should be_true
-        headers.includes_word?("X-RESPONSE-USER-ROUTE", "true").should be_true
-        headers.includes_word?("X-REQUEST-NOT-POSTS-ROUTE", "true").should be_true
-        headers.get?("X-RESPONSE-GLOBAL").should_not be_nil
+describe Athena::Routing::Callback do
+  do_with_config
+
+  describe "user endpoint" do
+    it "should set the correct headers" do
+      headers = CLIENT.get("/callback/users").headers
+      headers.includes_word?("X-RESPONSE-ALL-ROUTES", "true").should be_true
+      headers.includes_word?("X-RESPONSE-USER-ROUTE", "true").should be_true
+      headers.includes_word?("X-REQUEST-NOT-POSTS-ROUTE", "true").should be_true
+      headers.get?("X-RESPONSE-GLOBAL").should_not be_nil
+    end
+  end
+
+  describe "all endpoint" do
+    it "should set the correct headers" do
+      headers = CLIENT.get("/callback/all").headers
+      headers.includes_word?("X-RESPONSE-ALL-ROUTES", "true").should be_true
+      headers.includes_word?("X-RESPONSE-USER-ROUTE", "true").should be_false
+      headers.includes_word?("X-REQUEST-NOT-POSTS-ROUTE", "true").should be_true
+      headers.get?("X-RESPONSE-GLOBAL").should_not be_nil
+    end
+  end
+
+  describe "for an excluded endpoint" do
+    it "should set the correct headers" do
+      headers = CLIENT.get("/callback/posts").headers
+      headers.includes_word?("X-RESPONSE-ALL-ROUTES", "true").should be_true
+      headers.includes_word?("X-RESPONSE-USER-ROUTE", "true").should be_false
+      headers.includes_word?("X-REQUEST-NOT-POSTS-ROUTE", "true").should be_false
+      headers.get?("X-RESPONSE-GLOBAL").should be_nil
+    end
+  end
+
+  describe "in another controller" do
+    it "should not set the `CallbackController`'s' headers" do
+      headers = CLIENT.get("/callback/other").headers
+      headers.includes_word?("X-RESPONSE-ALL-ROUTES", "true").should be_false
+      headers.includes_word?("X-RESPONSE-USER-ROUTE", "true").should be_false
+      headers.includes_word?("X-REQUEST-NOT-POSTS-ROUTE", "true").should be_false
+      headers.get?("X-RESPONSE-GLOBAL").should_not be_nil
+    end
+
+    it "should set the global callback header" do
+      headers = CLIENT.get("/callback/other").headers
+      headers.get?("X-RESPONSE-GLOBAL").should_not be_nil
+    end
+  end
+
+  describe "inheritence" do
+    describe "parent" do
+      it "should have just the parent header" do
+        headers = CLIENT.get("/callback/nested/parent").headers
+        global_header = headers.get("X-RESPONSE-GLOBAL")
+        global_header.should_not be_nil
+
+        parent_header = headers.get("X-RESPONSE-PARENT")
+        parent_header.should_not be_nil
+
+        (global_header.first.to_i64 <= parent_header.first.to_i64).should be_true
+
+        headers.has_key?("X-RESPONSE-CHILD1").should be_false
+        headers.has_key?("X-RESPONSE-CHILD2").should be_false
       end
     end
 
-    describe "all endpoint" do
-      it "should set the correct headers" do
-        headers = client.get("/callback/all").headers
-        headers.includes_word?("X-RESPONSE-ALL-ROUTES", "true").should be_true
-        headers.includes_word?("X-RESPONSE-USER-ROUTE", "true").should be_false
-        headers.includes_word?("X-REQUEST-NOT-POSTS-ROUTE", "true").should be_true
-        headers.get?("X-RESPONSE-GLOBAL").should_not be_nil
+    describe "child1" do
+      it "should have the parent and child1 headers" do
+        headers = CLIENT.get("/callback/nested/child").headers
+        global_header = headers.get("X-RESPONSE-GLOBAL")
+        global_header.should_not be_nil
+
+        parent_header = headers.get("X-RESPONSE-PARENT")
+        parent_header.should_not be_nil
+
+        child1_header = headers.get("X-RESPONSE-CHILD1")
+        child1_header.should_not be_nil
+
+        (global_header.first.to_i64 <= parent_header.first.to_i64 < child1_header.first.to_i64).should be_true
+
+        child2_header = headers.get?("X-RESPONSE-CHILD2")
+        child2_header.should be_nil
       end
     end
 
-    describe "for an excluded endpoint" do
-      it "should set the correct headers" do
-        headers = client.get("/callback/posts").headers
-        headers.includes_word?("X-RESPONSE-ALL-ROUTES", "true").should be_true
-        headers.includes_word?("X-RESPONSE-USER-ROUTE", "true").should be_false
-        headers.includes_word?("X-REQUEST-NOT-POSTS-ROUTE", "true").should be_false
-        headers.get?("X-RESPONSE-GLOBAL").should be_nil
+    describe "child2" do
+      it "should have the parent, child1 and child2 headers" do
+        headers = CLIENT.get("/callback/nested/child2").headers
+        global_header = headers.get("X-RESPONSE-GLOBAL")
+        global_header.should_not be_nil
+
+        parent_header = headers.get("X-RESPONSE-PARENT")
+        parent_header.should_not be_nil
+
+        child1_header = headers.get("X-RESPONSE-CHILD1")
+        child1_header.should_not be_nil
+
+        child2_header = headers.get("X-RESPONSE-CHILD2")
+        child2_header.should_not be_nil
+
+        (parent_header.first.to_i64 < child1_header.first.to_i64 < child2_header.first.to_i64).should be_true
       end
     end
 
-    describe "in another controller" do
-      it "should not set the `CallbackController`'s' headers" do
-        headers = client.get("/callback/other").headers
-        headers.includes_word?("X-RESPONSE-ALL-ROUTES", "true").should be_false
-        headers.includes_word?("X-RESPONSE-USER-ROUTE", "true").should be_false
-        headers.includes_word?("X-REQUEST-NOT-POSTS-ROUTE", "true").should be_false
-        headers.get?("X-RESPONSE-GLOBAL").should_not be_nil
-      end
+    describe "child3" do
+      it "should have the parent header" do
+        headers = CLIENT.get("/callback/nested/child3").headers
+        global_header = headers.get("X-RESPONSE-GLOBAL")
+        global_header.should_not be_nil
 
-      it "should set the global callback header" do
-        headers = client.get("/callback/other").headers
-        headers.get?("X-RESPONSE-GLOBAL").should_not be_nil
-      end
-    end
+        parent_header = headers.get("X-RESPONSE-PARENT")
+        parent_header.should_not be_nil
 
-    describe "inheritence" do
-      describe "parent" do
-        it "should have just the parent header" do
-          headers = client.get("/callback/nested/parent").headers
-          global_header = headers.get("X-RESPONSE-GLOBAL")
-          global_header.should_not be_nil
+        (global_header.first.to_i64 <= parent_header.first.to_i64).should be_true
 
-          parent_header = headers.get("X-RESPONSE-PARENT")
-          parent_header.should_not be_nil
+        child1_header = headers.get?("X-RESPONSE-CHILD1")
+        child1_header.should be_nil
 
-          (global_header.first.to_i64 <= parent_header.first.to_i64).should be_true
-
-          headers.has_key?("X-RESPONSE-CHILD1").should be_false
-          headers.has_key?("X-RESPONSE-CHILD2").should be_false
-        end
-      end
-
-      describe "child1" do
-        it "should have the parent and child1 headers" do
-          headers = client.get("/callback/nested/child").headers
-          global_header = headers.get("X-RESPONSE-GLOBAL")
-          global_header.should_not be_nil
-
-          parent_header = headers.get("X-RESPONSE-PARENT")
-          parent_header.should_not be_nil
-
-          child1_header = headers.get("X-RESPONSE-CHILD1")
-          child1_header.should_not be_nil
-
-          (global_header.first.to_i64 <= parent_header.first.to_i64 < child1_header.first.to_i64).should be_true
-
-          child2_header = headers.get?("X-RESPONSE-CHILD2")
-          child2_header.should be_nil
-        end
-      end
-
-      describe "child2" do
-        it "should have the parent, child1 and child2 headers" do
-          headers = client.get("/callback/nested/child2").headers
-          global_header = headers.get("X-RESPONSE-GLOBAL")
-          global_header.should_not be_nil
-
-          parent_header = headers.get("X-RESPONSE-PARENT")
-          parent_header.should_not be_nil
-
-          child1_header = headers.get("X-RESPONSE-CHILD1")
-          child1_header.should_not be_nil
-
-          child2_header = headers.get("X-RESPONSE-CHILD2")
-          child2_header.should_not be_nil
-
-          (parent_header.first.to_i64 < child1_header.first.to_i64 < child2_header.first.to_i64).should be_true
-        end
-      end
-
-      describe "child3" do
-        it "should have the parent header" do
-          headers = client.get("/callback/nested/child3").headers
-          global_header = headers.get("X-RESPONSE-GLOBAL")
-          global_header.should_not be_nil
-
-          parent_header = headers.get("X-RESPONSE-PARENT")
-          parent_header.should_not be_nil
-
-          (global_header.first.to_i64 <= parent_header.first.to_i64).should be_true
-
-          child1_header = headers.get?("X-RESPONSE-CHILD1")
-          child1_header.should be_nil
-
-          child2_header = headers.get?("X-RESPONSE-CHILD2")
-          child2_header.should be_nil
-        end
+        child2_header = headers.get?("X-RESPONSE-CHILD2")
+        child2_header.should be_nil
       end
     end
   end

--- a/spec/routing/casting_spec.cr
+++ b/spec/routing/casting_spec.cr
@@ -1,105 +1,105 @@
 require "./routing_spec_helper"
 
-do_with_config do |client|
-  describe "param casting" do
-    describe Int do
-      it Int8 do
-        client.get("/int8/123").body.should eq "123"
-        client.post("/int8", body: "123", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "123"
-      end
+describe "param casting" do
+  do_with_config
 
-      it Int16 do
-        client.get("/int16/456").body.should eq "456"
-        client.post("/int16/", body: "456", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "456"
-      end
-
-      it Int32 do
-        client.get("/int32/111111").body.should eq "111111"
-        client.post("/int32/", body: "111111", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "111111"
-      end
-
-      it Int64 do
-        client.get("/int64/9999999999999999").body.should eq "9999999999999999"
-        client.post("/int64/", body: "9999999999999999", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "9999999999999999"
-      end
-
-      pending Int128 do
-        client.get("/int128/9999999999999999999999").body.should eq "9999999999999999999999"
-        client.post("/int128/", body: "9999999999999999999999", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "9999999999999999999999"
-      end
-
-      it "invalid" do
-        response = client.get("/int32/1.00")
-        response.body.should eq %({"code": 400, "message": "Invalid Int32: 1.00"})
-        response.status.should eq HTTP::Status::BAD_REQUEST
-      end
-
-      it UInt8 do
-        client.get("/uint8/123").body.should eq "123"
-        client.post("/uint8", body: "123", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "123"
-      end
-
-      it UInt16 do
-        client.get("/uint16/456").body.should eq "456"
-        client.post("/uint16", body: "456", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "456"
-      end
-
-      it UInt32 do
-        client.get("/uint32/111111").body.should eq "111111"
-        client.post("/uint32", body: "111111", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "111111"
-      end
-
-      it UInt64 do
-        client.get("/uint64/9999999999999999").body.should eq "9999999999999999"
-        client.post("/uint64/", body: "9999999999999999", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "9999999999999999"
-      end
-
-      pending UInt128 do
-        client.get("/uint128/9999999999999999999999").body.should eq "9999999999999999999999"
-        client.post("/uint128/", body: "9999999999999999999999", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "9999999999999999999999"
-      end
-
-      it "invalid" do
-        response = client.get("/uint8/256")
-        response.body.should eq %({"code": 400, "message": "Invalid UInt8: 256"})
-        response.status.should eq HTTP::Status::BAD_REQUEST
-      end
+  describe Int do
+    it Int8 do
+      CLIENT.get("/int8/123").body.should eq "123"
+      CLIENT.post("/int8", body: "123", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "123"
     end
 
-    describe Float do
-      it Float32 do
-        client.get("/float32/-2342.223").body.should eq "-2342.223"
-        client.post("/float32/", body: "-2342.223", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "-2342.223"
-      end
-
-      it Float64 do
-        client.get("/float64/2342.234234234223").body.should eq "2342.234234234223"
-        client.post("/float64", body: "2342.234234234223", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "2342.234234234223"
-      end
-
-      it "invalid" do
-        response = client.get("/float64/foo")
-        response.body.should eq %({"code": 400, "message": "Invalid Float64: foo"})
-        response.status.should eq HTTP::Status::BAD_REQUEST
-      end
+    it Int16 do
+      CLIENT.get("/int16/456").body.should eq "456"
+      CLIENT.post("/int16/", body: "456", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "456"
     end
 
-    it Bool do
-      client.get("/bool/true").body.should eq "true"
-      client.post("/bool", body: "true", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "true"
+    it Int32 do
+      CLIENT.get("/int32/111111").body.should eq "111111"
+      CLIENT.post("/int32/", body: "111111", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "111111"
     end
 
-    it String do
-      client.get("/string/sdfsd").body.should eq "\"sdfsd\""
-      client.post("/string", body: "sdfsd", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq %("sdfsd")
-      client.post("/json/string", body: %({"body": "FOO"}), headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq %({"body":"FOO"})
+    it Int64 do
+      CLIENT.get("/int64/9999999999999999").body.should eq "9999999999999999"
+      CLIENT.post("/int64/", body: "9999999999999999", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "9999999999999999"
     end
 
-    describe "Negative values" do
-      it "should return properly" do
-        client.get("/negative/123").body.should eq "-123"
-        client.post("/negative", body: "123", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "-123"
-      end
+    pending Int128 do
+      CLIENT.get("/int128/9999999999999999999999").body.should eq "9999999999999999999999"
+      CLIENT.post("/int128/", body: "9999999999999999999999", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "9999999999999999999999"
+    end
+
+    it "invalid" do
+      response = CLIENT.get("/int32/1.00")
+      response.body.should eq %({"code": 400, "message": "Invalid Int32: 1.00"})
+      response.status.should eq HTTP::Status::BAD_REQUEST
+    end
+
+    it UInt8 do
+      CLIENT.get("/uint8/123").body.should eq "123"
+      CLIENT.post("/uint8", body: "123", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "123"
+    end
+
+    it UInt16 do
+      CLIENT.get("/uint16/456").body.should eq "456"
+      CLIENT.post("/uint16", body: "456", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "456"
+    end
+
+    it UInt32 do
+      CLIENT.get("/uint32/111111").body.should eq "111111"
+      CLIENT.post("/uint32", body: "111111", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "111111"
+    end
+
+    it UInt64 do
+      CLIENT.get("/uint64/9999999999999999").body.should eq "9999999999999999"
+      CLIENT.post("/uint64/", body: "9999999999999999", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "9999999999999999"
+    end
+
+    pending UInt128 do
+      CLIENT.get("/uint128/9999999999999999999999").body.should eq "9999999999999999999999"
+      CLIENT.post("/uint128/", body: "9999999999999999999999", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "9999999999999999999999"
+    end
+
+    it "invalid" do
+      response = CLIENT.get("/uint8/256")
+      response.body.should eq %({"code": 400, "message": "Invalid UInt8: 256"})
+      response.status.should eq HTTP::Status::BAD_REQUEST
+    end
+  end
+
+  describe Float do
+    it Float32 do
+      CLIENT.get("/float32/-2342.223").body.should eq "-2342.223"
+      CLIENT.post("/float32/", body: "-2342.223", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "-2342.223"
+    end
+
+    it Float64 do
+      CLIENT.get("/float64/2342.234234234223").body.should eq "2342.234234234223"
+      CLIENT.post("/float64", body: "2342.234234234223", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "2342.234234234223"
+    end
+
+    it "invalid" do
+      response = CLIENT.get("/float64/foo")
+      response.body.should eq %({"code": 400, "message": "Invalid Float64: foo"})
+      response.status.should eq HTTP::Status::BAD_REQUEST
+    end
+  end
+
+  it Bool do
+    CLIENT.get("/bool/true").body.should eq "true"
+    CLIENT.post("/bool", body: "true", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "true"
+  end
+
+  it String do
+    CLIENT.get("/string/sdfsd").body.should eq "\"sdfsd\""
+    CLIENT.post("/string", body: "sdfsd", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq %("sdfsd")
+    CLIENT.post("/json/string", body: %({"body": "FOO"}), headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq %({"body":"FOO"})
+  end
+
+  describe "Negative values" do
+    it "should return properly" do
+      CLIENT.get("/negative/123").body.should eq "-123"
+      CLIENT.post("/negative", body: "123", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "-123"
     end
   end
 end

--- a/spec/routing/compile_spec.cr
+++ b/spec/routing/compile_spec.cr
@@ -94,6 +94,12 @@ describe Athena::Routing do
       end
     end
 
+    describe "where controller does not have any non abstract children" do
+      it "should not compile" do
+        assert_error "routing/compiler/actions/no_non_abstract_children.cr", "ParentController does not have any non abstract children."
+      end
+    end
+
     describe "without a return type" do
       it "should not compile" do
         assert_error "routing/compiler/actions/no_return_type.cr", "Route action return type must be set for 'CompileController#no_return_type'"

--- a/spec/routing/compiler/actions/callback_instance_method.cr
+++ b/spec/routing/compiler/actions/callback_instance_method.cr
@@ -1,6 +1,6 @@
 require "../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Callback(event: CallbackEvents::OnResponse)]
   def teapot_callback(context : HTTP::Server::Context) : Nil
     context.response.status = HTTP::Status::IM_A_TEAPOT

--- a/spec/routing/compiler/actions/class_method_action.cr
+++ b/spec/routing/compiler/actions/class_method_action.cr
@@ -1,6 +1,6 @@
 require "../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/")]
   def self.class_method : Int32
     123

--- a/spec/routing/compiler/actions/handle_exception_instance_method.cr
+++ b/spec/routing/compiler/actions/handle_exception_instance_method.cr
@@ -1,6 +1,6 @@
 require "../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   def handle_exception(exception : Exception, ctx : HTTP::Server::Context)
     super
   end

--- a/spec/routing/compiler/actions/no_non_abstract_children.cr
+++ b/spec/routing/compiler/actions/no_non_abstract_children.cr
@@ -1,0 +1,17 @@
+require "../../routing_spec_helper"
+
+abstract struct ParentController < Athena::Routing::Controller
+  @[Athena::Routing::Get(path: "int8/")]
+  def parent_method : Int32
+    123
+  end
+end
+
+abstract struct ChildController < ParentController
+  @[Athena::Routing::Get(path: "int8/")]
+  def child_method : Int32
+    456
+  end
+end
+
+Athena::Routing.run

--- a/spec/routing/compiler/actions/no_return_type.cr
+++ b/spec/routing/compiler/actions/no_return_type.cr
@@ -1,6 +1,6 @@
 require "../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/")]
   def no_return_type
     123

--- a/spec/routing/compiler/converters/exists/no_find.cr
+++ b/spec/routing/compiler/converters/exists/no_find.cr
@@ -1,9 +1,9 @@
 require "../../../routing_spec_helper"
 
-class NoFind
+struct NoFind
 end
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Post(path: "/")]
   @[Athena::Routing::ParamConverter(param: "body", type: NoFind, pk_type: Int64, converter: Exists)]
   def no_find(body : NoFind) : Int32

--- a/spec/routing/compiler/converters/exists/no_pk_type.cr
+++ b/spec/routing/compiler/converters/exists/no_pk_type.cr
@@ -1,10 +1,10 @@
 require "../../../routing_spec_helper"
 
-class NoPk
+struct NoPk
   def self.find(id); end
 end
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Post(path: "/")]
   @[Athena::Routing::ParamConverter(param: "body", type: NoPk, converter: Exists)]
   def no_pk_type(body : NoPk) : Int32

--- a/spec/routing/compiler/converters/form_data/no_from_form_data.cr
+++ b/spec/routing/compiler/converters/form_data/no_from_form_data.cr
@@ -1,9 +1,9 @@
 require "../../../routing_spec_helper"
 
-class NoFormData
+struct NoFormData
 end
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Post(path: "/")]
   @[Athena::Routing::ParamConverter(param: "body", type: NoFormData, converter: FormData)]
   def no_from_data(body : NoFormData) : Int32

--- a/spec/routing/compiler/converters/no_converter.cr
+++ b/spec/routing/compiler/converters/no_converter.cr
@@ -1,9 +1,9 @@
 require "../../routing_spec_helper"
 
-class NoConverter
+struct NoConverter
 end
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Post(path: "/")]
   @[Athena::Routing::ParamConverter(param: "body", type: NoConverter)]
   def no_converter(body : NoConverter) : Int32

--- a/spec/routing/compiler/converters/no_param.cr
+++ b/spec/routing/compiler/converters/no_param.cr
@@ -1,9 +1,9 @@
 require "../../routing_spec_helper"
 
-class NoParam
+struct NoParam
 end
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Post(path: "/")]
   @[Athena::Routing::ParamConverter(type: NoParam, converter: Exists)]
   def no_param(body : NoParam) : Int32

--- a/spec/routing/compiler/converters/no_type.cr
+++ b/spec/routing/compiler/converters/no_type.cr
@@ -1,9 +1,9 @@
 require "../../routing_spec_helper"
 
-class NoType
+struct NoType
 end
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Post(path: "/")]
   @[Athena::Routing::ParamConverter(param: "body", converter: Exists)]
   def no_type(body : NoType) : Int32

--- a/spec/routing/compiler/converters/one_invalid.cr
+++ b/spec/routing/compiler/converters/one_invalid.cr
@@ -1,14 +1,14 @@
 require "../../routing_spec_helper"
 
-class NoPk
+struct NoPk
   def self.find(id); end
 end
 
-class Model
+struct Model
   def self.find(id); end
 end
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Post(path: "/:pk_id")]
   @[Athena::Routing::ParamConverter(param: "body", type: Model, converter: RequestBody)]
   @[Athena::Routing::ParamConverter(param: "body", type: NoPk, converter: Exists)]

--- a/spec/routing/compiler/parameters/action/no_action_one_path.cr
+++ b/spec/routing/compiler/parameters/action/no_action_one_path.cr
@@ -1,6 +1,6 @@
 require "../../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/:value")]
   def no_action_one_path : Int32
     123

--- a/spec/routing/compiler/parameters/action/no_action_one_query.cr
+++ b/spec/routing/compiler/parameters/action/no_action_one_query.cr
@@ -1,6 +1,6 @@
 require "../../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/", query: {"bar" => /bar/})]
   def no_action_one_query : Int32
     123

--- a/spec/routing/compiler/parameters/action/one_action_id_one_path.cr
+++ b/spec/routing/compiler/parameters/action/one_action_id_one_path.cr
@@ -1,6 +1,6 @@
 require "../../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/:num")]
   def one_action_id_one_path(num_id : String) : Int32
     123

--- a/spec/routing/compiler/parameters/action/one_action_id_one_query.cr
+++ b/spec/routing/compiler/parameters/action/one_action_id_one_query.cr
@@ -1,6 +1,6 @@
 require "../../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/", query: {"num" => /\d+/})]
   def one_action_id_one_query(num_id : String) : Int32
     123

--- a/spec/routing/compiler/parameters/action/one_action_one_query_one_path_path.cr
+++ b/spec/routing/compiler/parameters/action/one_action_one_query_one_path_path.cr
@@ -1,6 +1,6 @@
 require "../../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/:bar", query: {"foo" => /bar/})]
   def one_action_one_query_one_path_path(foo : String) : Int32
     123

--- a/spec/routing/compiler/parameters/action/one_action_one_query_one_path_query.cr
+++ b/spec/routing/compiler/parameters/action/one_action_one_query_one_path_query.cr
@@ -1,6 +1,6 @@
 require "../../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/:foo", query: {"bar" => /bar/})]
   def one_action_one_query_one_path_query(foo : String) : Int32
     123

--- a/spec/routing/compiler/parameters/action/one_action_two_path.cr
+++ b/spec/routing/compiler/parameters/action/one_action_two_path.cr
@@ -1,6 +1,6 @@
 require "../../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/:foo/:bar")]
   def one_action_two_path(foo : String) : Int32
     123

--- a/spec/routing/compiler/parameters/action/one_action_two_query.cr
+++ b/spec/routing/compiler/parameters/action/one_action_two_query.cr
@@ -1,6 +1,6 @@
 require "../../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/", query: {"foo" => nil, "bar" => /bar/})]
   def one_action_two_query(foo : String) : Int32
     123

--- a/spec/routing/compiler/parameters/path/one_action_no_path.cr
+++ b/spec/routing/compiler/parameters/path/one_action_no_path.cr
@@ -1,6 +1,6 @@
 require "../../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/")]
   def one_action_no_path(foo : String) : Int32
     123

--- a/spec/routing/compiler/parameters/path/two_action_one_path.cr
+++ b/spec/routing/compiler/parameters/path/two_action_one_path.cr
@@ -1,6 +1,6 @@
 require "../../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/(:foo)")]
   def two_action_one_path(foo : String, bar : Bool) : Int32
     123

--- a/spec/routing/compiler/parameters/query/one_action_no_query.cr
+++ b/spec/routing/compiler/parameters/query/one_action_no_query.cr
@@ -1,6 +1,6 @@
 require "../../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/")]
   def one_action_no_query(foo : String) : Int32
     123

--- a/spec/routing/compiler/parameters/query/two_action_one_query.cr
+++ b/spec/routing/compiler/parameters/query/two_action_one_query.cr
@@ -1,6 +1,6 @@
 require "../../../routing_spec_helper"
 
-class CompileController < Athena::Routing::Controller
+struct CompileController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/", query: {"foo" => nil})]
   def two_action_one_query(foo : String, bar : Bool) : Int32
     123

--- a/spec/routing/constraints_spec.cr
+++ b/spec/routing/constraints_spec.cr
@@ -1,19 +1,19 @@
 require "./routing_spec_helper"
 
-do_with_config do |client|
-  describe "Constraints" do
-    describe "that is valid" do
-      it "works" do
-        client.get("/get/constraints/4:5:6").body.should eq "\"4:5:6\""
-      end
-    end
+describe "Constraints" do
+  do_with_config
 
-    describe "that is invalid" do
-      it "returns correct error" do
-        response = client.get("/get/constraints/4:a:6")
-        response.body.should eq %({"code":404,"message":"No route found for 'GET /get/constraints/4:a:6'"})
-        response.status.should eq HTTP::Status::NOT_FOUND
-      end
+  describe "that is valid" do
+    it "works" do
+      CLIENT.get("/get/constraints/4:5:6").body.should eq "\"4:5:6\""
+    end
+  end
+
+  describe "that is invalid" do
+    it "returns correct error" do
+      response = CLIENT.get("/get/constraints/4:a:6")
+      response.body.should eq %({"code":404,"message":"No route found for 'GET /get/constraints/4:a:6'"})
+      response.status.should eq HTTP::Status::NOT_FOUND
     end
   end
 end

--- a/spec/routing/controllers/article_controller.cr
+++ b/spec/routing/controllers/article_controller.cr
@@ -20,7 +20,7 @@ class Article
   end
 end
 
-class ArticleController < Athena::Routing::Controller
+struct ArticleController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "article/:article_identity_id")]
   @[Athena::Routing::ParamConverter(param: "article_identity", pk_type: Int64, type: Article, converter: Athena::Routing::Converters::Exists)]
   def get_article(article_identity : Article) : Article

--- a/spec/routing/controllers/athena_controller.cr
+++ b/spec/routing/controllers/athena_controller.cr
@@ -1,4 +1,4 @@
-class AthenaController < Athena::Routing::Controller
+struct AthenaController < Athena::Routing::Controller
   include Athena::DI::Injectable
 
   def initialize(@request_stack : Athena::Routing::RequestStack); end

--- a/spec/routing/controllers/bool_controller.cr
+++ b/spec/routing/controllers/bool_controller.cr
@@ -1,4 +1,4 @@
-class BoolController < Athena::Routing::Controller
+struct BoolController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "bool/:val")]
   def bool(val : Bool) : Bool
     val.should be_a Bool

--- a/spec/routing/controllers/callback_controller.cr
+++ b/spec/routing/controllers/callback_controller.cr
@@ -1,11 +1,11 @@
-class Athena::Routing::Controller
+abstract struct Athena::Routing::Controller
   @[Athena::Routing::Callback(event: CallbackEvents::OnResponse, exclude: ["posts"])]
   def self.global_callback(context : HTTP::Server::Context) : Nil
     context.response.headers.add "X-RESPONSE-GLOBAL", Time.utc.to_unix.to_s
   end
 end
 
-class CallbackController < Athena::Routing::Controller
+struct CallbackController < Athena::Routing::Controller
   @[Athena::Routing::Callback(event: CallbackEvents::OnResponse)]
   def self.after_all(context : HTTP::Server::Context) : Nil
     context.response.headers.add "X-RESPONSE-ALL-ROUTES", "true"
@@ -37,7 +37,7 @@ class CallbackController < Athena::Routing::Controller
   end
 end
 
-class OtherCallbackController < Athena::Routing::Controller
+struct OtherCallbackController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "/callback/other")]
   def other : String
     "other"
@@ -46,7 +46,7 @@ end
 
 # Nested to test callback inheritence
 
-class ZestedCallbackController < Athena::Routing::Controller
+abstract struct ZestedCallbackController < Athena::Routing::Controller
   @[Athena::Routing::Callback(event: CallbackEvents::OnResponse)]
   def self.parent_callback(context : HTTP::Server::Context) : Nil
     context.response.headers.add "X-RESPONSE-PARENT", Time.utc.to_unix.to_s
@@ -59,7 +59,7 @@ class ZestedCallbackController < Athena::Routing::Controller
   end
 end
 
-class AestedCallback2Controller < ZestedCallbackController
+abstract struct AestedCallback2Controller < ZestedCallbackController
   @[Athena::Routing::Callback(event: CallbackEvents::OnResponse)]
   def self.child1_callback(context : HTTP::Server::Context) : Nil
     context.response.headers.add "X-RESPONSE-CHILD1", Time.utc.to_unix.to_s
@@ -72,7 +72,7 @@ class AestedCallback2Controller < ZestedCallbackController
   end
 end
 
-class NestedCallback3Controller < AestedCallback2Controller
+struct NestedCallback3Controller < AestedCallback2Controller
   @[Athena::Routing::Callback(event: CallbackEvents::OnResponse)]
   def self.child2_callback(context : HTTP::Server::Context) : Nil
     context.response.headers.add "X-RESPONSE-CHILD2", Time.utc.to_unix.to_s
@@ -85,7 +85,7 @@ class NestedCallback3Controller < AestedCallback2Controller
   end
 end
 
-class NestedCallback4Controller < ZestedCallbackController
+struct NestedCallback4Controller < ZestedCallbackController
   @[Athena::Routing::Get(path: "/callback/nested/child3")]
   def child : String
     "child3"

--- a/spec/routing/controllers/cors_controller.cr
+++ b/spec/routing/controllers/cors_controller.cr
@@ -1,4 +1,4 @@
-class DefaultController < Athena::Routing::Controller
+struct DefaultController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "defaults")]
   def cors_defaults : String
     "default"
@@ -11,7 +11,7 @@ class DefaultController < Athena::Routing::Controller
 end
 
 @[Athena::Routing::ControllerOptions(cors: "class_overload")]
-class OverloadController < Athena::Routing::Controller
+abstract struct OverloadController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "class_overload")]
   def cors_class_overload : String
     "class_overload"
@@ -28,7 +28,7 @@ class OverloadController < Athena::Routing::Controller
   end
 end
 
-class InheritenceController < OverloadController
+struct InheritenceController < OverloadController
   @[Athena::Routing::Get(path: "inheritence")]
   def inheritence : String
     "inheritence"

--- a/spec/routing/controllers/exception_controller.cr
+++ b/spec/routing/controllers/exception_controller.cr
@@ -1,6 +1,6 @@
 require "../routing_spec_helper"
 
-class Parent1 < Athena::Routing::Controller
+abstract struct Parent1 < Athena::Routing::Controller
   def self.handle_exception(exception : Exception, ctx : HTTP::Server::Context, location : String = "unknown")
     if exception.is_a? DivisionByZeroError
       throw 666, %({"code": 666, "message": "#{exception.message}"})
@@ -10,10 +10,10 @@ class Parent1 < Athena::Routing::Controller
   end
 end
 
-class Parent2 < Athena::Routing::Controller
+abstract struct Parent2 < Athena::Routing::Controller
 end
 
-class Parent3 < Athena::Routing::Controller
+abstract struct Parent3 < Athena::Routing::Controller
   def self.handle_exception(exception : Exception, ctx : HTTP::Server::Context, location : String = "unknown")
     if exception.is_a? DivisionByZeroError
       throw 400, %({"code": 400, "message": "#{exception.message}"})
@@ -23,21 +23,21 @@ class Parent3 < Athena::Routing::Controller
   end
 end
 
-class Test1 < Parent1
+struct Test1 < Parent1
   @[Athena::Routing::Get(path: "exception/custom")]
   def get_custom_exception : Nil
     raise DivisionByZeroError.new
   end
 end
 
-class Test2 < Parent2
+struct Test2 < Parent2
   @[Athena::Routing::Get(path: "exception/default")]
   def get_default_exception : Nil
     raise NilAssertionError.new
   end
 end
 
-class Test3 < Parent3
+struct Test3 < Parent3
   @[Athena::Routing::Get(path: "exception/no_match")]
   def get_no_match_exception : Nil
     raise NilAssertionError.new

--- a/spec/routing/controllers/float_controller.cr
+++ b/spec/routing/controllers/float_controller.cr
@@ -1,4 +1,4 @@
-class FloatController < Athena::Routing::Controller
+struct FloatController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "float32/:num")]
   def float32(num : Float32) : Float32
     num.should be_a Float32

--- a/spec/routing/controllers/int_controller.cr
+++ b/spec/routing/controllers/int_controller.cr
@@ -1,4 +1,4 @@
-class IntController < Athena::Routing::Controller
+struct IntController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "int8/:num")]
   def int8(num : Int8) : Int8
     num.should be_a Int8

--- a/spec/routing/controllers/prefix_controller.cr
+++ b/spec/routing/controllers/prefix_controller.cr
@@ -1,5 +1,5 @@
 @[Athena::Routing::ControllerOptions(prefix: "calendar")]
-class CalendarController < Athena::Routing::Controller
+abstract struct CalendarController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "events")]
   def events : String
     "events"
@@ -17,9 +17,9 @@ class CalendarController < Athena::Routing::Controller
 end
 
 @[Athena::Routing::ControllerOptions(prefix: "/:app_name")]
-class CalendarChildController < CalendarController
+struct CalendarChildController < CalendarController
   @[Athena::Routing::Get(path: "child1")]
-  def calendar(app_name : String) : String
+  def calendar_app(app_name : String) : String
     "child1 + #{app_name}"
   end
 end

--- a/spec/routing/controllers/string_controller.cr
+++ b/spec/routing/controllers/string_controller.cr
@@ -1,4 +1,4 @@
-class StringController < Athena::Routing::Controller
+struct StringController < Athena::Routing::Controller
   @[Athena::Routing::Get(path: "string/:val")]
   def string(val : String) : String
     val.should be_a String

--- a/spec/routing/controllers/user_controller.cr
+++ b/spec/routing/controllers/user_controller.cr
@@ -65,7 +65,7 @@ struct CustomRenderer < Athena::Routing::Renderers::Renderer
   end
 end
 
-class UserController < Athena::Routing::Controller
+struct UserController < Athena::Routing::Controller
   @[Athena::Routing::Post(path: "users")]
   @[Athena::Routing::ParamConverter(param: "body", type: User, converter: Athena::Routing::Converters::RequestBody)]
   def new_user(body : User) : User

--- a/spec/routing/cors_spec.cr
+++ b/spec/routing/cors_spec.cr
@@ -1,309 +1,309 @@
 require "./routing_spec_helper"
 
-do_with_config(CORS_CONFIG) do |client|
-  describe Athena::Routing::Handlers::CorsHandler do
-    describe "defaults" do
-      describe "GET" do
-        it "should add the allow origin header" do
-          response = client.get("/defaults")
-          response.headers["Access-Control-Allow-Origin"]?.should eq "DEFAULT_DOMAIN"
-          response.headers["Vary"]?.should eq "Origin"
-        end
+describe Athena::Routing::Handlers::CorsHandler do
+  do_with_config(CORS_CONFIG)
 
-        it "should not add the credentials header" do
-          response = client.get("/defaults")
-          response.headers["Access-Control-Allow-Credentials"]?.should be_nil
-        end
-
-        it "should add the credentials header" do
-          response = client.get("/defaults")
-          response.headers["Access-Control-Expose-Headers"]?.should eq "DEFAULT1_EH,DEFAULT2_EH"
-        end
-
-        it "should not add the allow methods header" do
-          response = client.get("/defaults")
-          response.headers["Access-Control-Allow-Methods"]?.should be_nil
-        end
-
-        it "should not add the allow headers header" do
-          response = client.get("/defaults")
-          response.headers["Access-Control-Allow-Headers"]?.should be_nil
-        end
-
-        it "should not add the max age header" do
-          response = client.get("/defaults")
-          response.headers["Access-Control-Max-Age"]?.should be_nil
-        end
-
-        it "should return the correct response" do
-          response = client.get("/defaults")
-          response.body.should eq "\"default\""
-        end
+  describe "defaults" do
+    describe "GET" do
+      it "should add the allow origin header" do
+        response = CLIENT.get("/defaults")
+        response.headers["Access-Control-Allow-Origin"]?.should eq "DEFAULT_DOMAIN"
+        response.headers["Vary"]?.should eq "Origin"
       end
 
-      describe "OPTIONS" do
-        describe "invalid request" do
-          describe "with a missing Request-Method header" do
-            it "should return the proper error" do
-              response = client.options("/defaults")
-              response.body.should eq "{\"code\":403,\"message\":\"Preflight request header 'Access-Control-Request-Method' is missing.\"}"
-              response.status.should eq HTTP::Status::FORBIDDEN
-            end
-          end
+      it "should not add the credentials header" do
+        response = CLIENT.get("/defaults")
+        response.headers["Access-Control-Allow-Credentials"]?.should be_nil
+      end
 
-          describe "with a missing Request-Method header" do
-            it "should return the proper error" do
-              response = client.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET"})
-              response.body.should eq "{\"code\":403,\"message\":\"Preflight request header 'Access-Control-Request-Headers' is missing.\"}"
-              response.status.should eq HTTP::Status::FORBIDDEN
-            end
-          end
+      it "should add the credentials header" do
+        response = CLIENT.get("/defaults")
+        response.headers["Access-Control-Expose-Headers"]?.should eq "DEFAULT1_EH,DEFAULT2_EH"
+      end
 
-          describe "with an invalid request method" do
-            it "should return the proper error" do
-              response = client.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "POST"})
-              response.body.should eq "{\"code\":405,\"message\":\"Request method 'POST' is not allowed.\"}"
-              response.status.should eq HTTP::Status::METHOD_NOT_ALLOWED
-            end
-          end
+      it "should not add the allow methods header" do
+        response = CLIENT.get("/defaults")
+        response.headers["Access-Control-Allow-Methods"]?.should be_nil
+      end
 
-          describe "with an invalid request header" do
-            it "should return the proper error" do
-              response = client.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "FOO"})
-              response.body.should eq "{\"code\":403,\"message\":\"Request header 'FOO' is not allowed.\"}"
-              response.status.should eq HTTP::Status::FORBIDDEN
-            end
-          end
-        end
+      it "should not add the allow headers header" do
+        response = CLIENT.get("/defaults")
+        response.headers["Access-Control-Allow-Headers"]?.should be_nil
+      end
 
-        it "should add the allow origin header" do
-          response = client.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "DEFAULT_AH"})
-          response.headers["Access-Control-Allow-Origin"]?.should eq "DEFAULT_DOMAIN"
-          response.headers["Vary"]?.should eq "Origin"
-        end
+      it "should not add the max age header" do
+        response = CLIENT.get("/defaults")
+        response.headers["Access-Control-Max-Age"]?.should be_nil
+      end
 
-        it "should not add the credentials header" do
-          response = client.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "DEFAULT_AH"})
-          response.headers["Access-Control-Allow-Credentials"]?.should be_nil
-        end
-
-        it "should add the credentials header" do
-          response = client.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "DEFAULT_AH"})
-          response.headers["Access-Control-Expose-Headers"]?.should eq "DEFAULT1_EH,DEFAULT2_EH"
-        end
-
-        it "should add the allow methods header" do
-          response = client.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "DEFAULT_AH"})
-          response.headers["Access-Control-Allow-Methods"]?.should eq "GET"
-        end
-
-        it "should add the allow headers header" do
-          response = client.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "DEFAULT_AH"})
-          response.headers["Access-Control-Allow-Headers"]?.should eq "DEFAULT_AH"
-        end
-
-        it "should add the max age header" do
-          response = client.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "DEFAULT_AH"})
-          response.headers["Access-Control-Max-Age"]?.should eq "123"
-        end
-
-        it "should NOT execute the action's handler" do
-          response = client.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "DEFAULT_AH"})
-          response.body.should eq ""
-          response.status.should eq HTTP::Status::OK
-        end
+      it "should return the correct response" do
+        response = CLIENT.get("/defaults")
+        response.body.should eq "\"default\""
       end
     end
 
-    describe "controller overload" do
+    describe "OPTIONS" do
+      describe "invalid request" do
+        describe "with a missing Request-Method header" do
+          it "should return the proper error" do
+            response = CLIENT.options("/defaults")
+            response.body.should eq "{\"code\":403,\"message\":\"Preflight request header 'Access-Control-Request-Method' is missing.\"}"
+            response.status.should eq HTTP::Status::FORBIDDEN
+          end
+        end
+
+        describe "with a missing Request-Method header" do
+          it "should return the proper error" do
+            response = CLIENT.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET"})
+            response.body.should eq "{\"code\":403,\"message\":\"Preflight request header 'Access-Control-Request-Headers' is missing.\"}"
+            response.status.should eq HTTP::Status::FORBIDDEN
+          end
+        end
+
+        describe "with an invalid request method" do
+          it "should return the proper error" do
+            response = CLIENT.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "POST"})
+            response.body.should eq "{\"code\":405,\"message\":\"Request method 'POST' is not allowed.\"}"
+            response.status.should eq HTTP::Status::METHOD_NOT_ALLOWED
+          end
+        end
+
+        describe "with an invalid request header" do
+          it "should return the proper error" do
+            response = CLIENT.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "FOO"})
+            response.body.should eq "{\"code\":403,\"message\":\"Request header 'FOO' is not allowed.\"}"
+            response.status.should eq HTTP::Status::FORBIDDEN
+          end
+        end
+      end
+
       it "should add the allow origin header" do
-        response = client.get("/class_overload")
+        response = CLIENT.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "DEFAULT_AH"})
+        response.headers["Access-Control-Allow-Origin"]?.should eq "DEFAULT_DOMAIN"
+        response.headers["Vary"]?.should eq "Origin"
+      end
+
+      it "should not add the credentials header" do
+        response = CLIENT.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "DEFAULT_AH"})
+        response.headers["Access-Control-Allow-Credentials"]?.should be_nil
+      end
+
+      it "should add the credentials header" do
+        response = CLIENT.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "DEFAULT_AH"})
+        response.headers["Access-Control-Expose-Headers"]?.should eq "DEFAULT1_EH,DEFAULT2_EH"
+      end
+
+      it "should add the allow methods header" do
+        response = CLIENT.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "DEFAULT_AH"})
+        response.headers["Access-Control-Allow-Methods"]?.should eq "GET"
+      end
+
+      it "should add the allow headers header" do
+        response = CLIENT.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "DEFAULT_AH"})
+        response.headers["Access-Control-Allow-Headers"]?.should eq "DEFAULT_AH"
+      end
+
+      it "should add the max age header" do
+        response = CLIENT.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "DEFAULT_AH"})
+        response.headers["Access-Control-Max-Age"]?.should eq "123"
+      end
+
+      it "should NOT execute the action's handler" do
+        response = CLIENT.options("/defaults", headers: HTTP::Headers{"Access-Control-Request-Method" => "GET", "Access-Control-Request-Headers" => "DEFAULT_AH"})
+        response.body.should eq ""
+        response.status.should eq HTTP::Status::OK
+      end
+    end
+  end
+
+  describe "controller overload" do
+    it "should add the allow origin header" do
+      response = CLIENT.get("/class_overload")
+      response.headers["Access-Control-Allow-Origin"]?.should eq "OVERLOAD_DOMAIN"
+      response.headers["Vary"]?.should eq "Origin"
+    end
+
+    it "should not add the credentials header" do
+      response = CLIENT.get("/class_overload")
+      response.headers["Access-Control-Allow-Credentials"]?.should be_nil
+    end
+
+    it "should add the credentials header" do
+      response = CLIENT.get("/class_overload")
+      response.headers["Access-Control-Expose-Headers"]?.should eq "DEFAULT1_EH,DEFAULT2_EH"
+    end
+
+    it "should not add the allow methods header" do
+      response = CLIENT.get("/class_overload")
+      response.headers["Access-Control-Allow-Methods"]?.should be_nil
+    end
+
+    it "should not add the allow headers header" do
+      response = CLIENT.get("/class_overload")
+      response.headers["Access-Control-Allow-Headers"]?.should be_nil
+    end
+
+    it "should not add the max age header" do
+      response = CLIENT.get("/class_overload")
+      response.headers["Access-Control-Max-Age"]?.should be_nil
+    end
+
+    it "should return the correct response" do
+      response = CLIENT.get("/class_overload")
+      response.body.should eq "\"class_overload\""
+    end
+  end
+
+  describe "action overload" do
+    it "should add the allow origin header" do
+      response = CLIENT.get("/action_overload")
+      response.headers["Access-Control-Allow-Origin"]?.should eq "ACTION_DOMAIN"
+      response.headers["Vary"]?.should eq "Origin"
+    end
+
+    it "should add the credentials header" do
+      response = CLIENT.get("/action_overload")
+      response.headers["Access-Control-Allow-Credentials"]?.should eq "true"
+    end
+
+    it "should add the credentials header" do
+      response = CLIENT.get("/action_overload")
+      response.headers["Access-Control-Expose-Headers"]?.should eq "DEFAULT1_EH,DEFAULT2_EH"
+    end
+
+    it "should not add the allow methods header" do
+      response = CLIENT.get("/action_overload")
+      response.headers["Access-Control-Allow-Methods"]?.should be_nil
+    end
+
+    it "should not add the allow headers header" do
+      response = CLIENT.get("/action_overload")
+      response.headers["Access-Control-Allow-Headers"]?.should be_nil
+    end
+
+    it "should not add the max age header" do
+      response = CLIENT.get("/action_overload")
+      response.headers["Access-Control-Max-Age"]?.should be_nil
+    end
+
+    it "should return the correct response" do
+      response = CLIENT.get("/action_overload")
+      response.body.should eq "\"action_overload\""
+    end
+  end
+
+  describe "disable overload" do
+    it "should not add the allow origin header" do
+      response = CLIENT.get("/disable_overload")
+      response.headers["Access-Control-Allow-Origin"]?.should be_nil
+      response.headers["Vary"]?.should be_nil
+    end
+
+    it "should not add the credentials header" do
+      response = CLIENT.get("/disable_overload")
+      response.headers["Access-Control-Allow-Credentials"]?.should be_nil
+    end
+
+    it "should not add the credentials header" do
+      response = CLIENT.get("/disable_overload")
+      response.headers["Access-Control-Expose-Headers"]?.should be_nil
+    end
+
+    it "should not add the allow methods header" do
+      response = CLIENT.get("/disable_overload")
+      response.headers["Access-Control-Allow-Methods"]?.should be_nil
+    end
+
+    it "should not add the allow headers header" do
+      response = CLIENT.get("/disable_overload")
+      response.headers["Access-Control-Allow-Headers"]?.should be_nil
+    end
+
+    it "should not add the max age header" do
+      response = CLIENT.get("/disable_overload")
+      response.headers["Access-Control-Max-Age"]?.should be_nil
+    end
+
+    it "should return the correct response" do
+      response = CLIENT.get("/disable_overload")
+      response.body.should eq "\"disable_overload\""
+    end
+  end
+
+  describe "inheritence" do
+    describe "with no overloads" do
+      it "should add the allow origin header" do
+        response = CLIENT.get("/inheritence")
         response.headers["Access-Control-Allow-Origin"]?.should eq "OVERLOAD_DOMAIN"
         response.headers["Vary"]?.should eq "Origin"
       end
 
       it "should not add the credentials header" do
-        response = client.get("/class_overload")
+        response = CLIENT.get("/inheritence")
         response.headers["Access-Control-Allow-Credentials"]?.should be_nil
       end
 
       it "should add the credentials header" do
-        response = client.get("/class_overload")
+        response = CLIENT.get("/inheritence")
         response.headers["Access-Control-Expose-Headers"]?.should eq "DEFAULT1_EH,DEFAULT2_EH"
       end
 
       it "should not add the allow methods header" do
-        response = client.get("/class_overload")
+        response = CLIENT.get("/inheritence")
         response.headers["Access-Control-Allow-Methods"]?.should be_nil
       end
 
       it "should not add the allow headers header" do
-        response = client.get("/class_overload")
+        response = CLIENT.get("/inheritence")
         response.headers["Access-Control-Allow-Headers"]?.should be_nil
       end
 
       it "should not add the max age header" do
-        response = client.get("/class_overload")
+        response = CLIENT.get("/inheritence")
         response.headers["Access-Control-Max-Age"]?.should be_nil
       end
 
       it "should return the correct response" do
-        response = client.get("/class_overload")
-        response.body.should eq "\"class_overload\""
+        response = CLIENT.get("/inheritence")
+        response.body.should eq "\"inheritence\""
       end
     end
 
-    describe "action overload" do
-      it "should add the allow origin header" do
-        response = client.get("/action_overload")
-        response.headers["Access-Control-Allow-Origin"]?.should eq "ACTION_DOMAIN"
-        response.headers["Vary"]?.should eq "Origin"
-      end
-
-      it "should add the credentials header" do
-        response = client.get("/action_overload")
-        response.headers["Access-Control-Allow-Credentials"]?.should eq "true"
-      end
-
-      it "should add the credentials header" do
-        response = client.get("/action_overload")
-        response.headers["Access-Control-Expose-Headers"]?.should eq "DEFAULT1_EH,DEFAULT2_EH"
-      end
-
-      it "should not add the allow methods header" do
-        response = client.get("/action_overload")
-        response.headers["Access-Control-Allow-Methods"]?.should be_nil
-      end
-
-      it "should not add the allow headers header" do
-        response = client.get("/action_overload")
-        response.headers["Access-Control-Allow-Headers"]?.should be_nil
-      end
-
-      it "should not add the max age header" do
-        response = client.get("/action_overload")
-        response.headers["Access-Control-Max-Age"]?.should be_nil
-      end
-
-      it "should return the correct response" do
-        response = client.get("/action_overload")
-        response.body.should eq "\"action_overload\""
-      end
-    end
-
-    describe "disable overload" do
+    describe "with a disable overload" do
       it "should not add the allow origin header" do
-        response = client.get("/disable_overload")
+        response = CLIENT.get("/inheritence_overload")
         response.headers["Access-Control-Allow-Origin"]?.should be_nil
         response.headers["Vary"]?.should be_nil
       end
 
       it "should not add the credentials header" do
-        response = client.get("/disable_overload")
+        response = CLIENT.get("/inheritence_overload")
         response.headers["Access-Control-Allow-Credentials"]?.should be_nil
       end
 
       it "should not add the credentials header" do
-        response = client.get("/disable_overload")
+        response = CLIENT.get("/inheritence_overload")
         response.headers["Access-Control-Expose-Headers"]?.should be_nil
       end
 
       it "should not add the allow methods header" do
-        response = client.get("/disable_overload")
+        response = CLIENT.get("/inheritence_overload")
         response.headers["Access-Control-Allow-Methods"]?.should be_nil
       end
 
       it "should not add the allow headers header" do
-        response = client.get("/disable_overload")
+        response = CLIENT.get("/inheritence_overload")
         response.headers["Access-Control-Allow-Headers"]?.should be_nil
       end
 
       it "should not add the max age header" do
-        response = client.get("/disable_overload")
+        response = CLIENT.get("/inheritence_overload")
         response.headers["Access-Control-Max-Age"]?.should be_nil
       end
 
       it "should return the correct response" do
-        response = client.get("/disable_overload")
-        response.body.should eq "\"disable_overload\""
-      end
-    end
-
-    describe "inheritence" do
-      describe "with no overloads" do
-        it "should add the allow origin header" do
-          response = client.get("/inheritence")
-          response.headers["Access-Control-Allow-Origin"]?.should eq "OVERLOAD_DOMAIN"
-          response.headers["Vary"]?.should eq "Origin"
-        end
-
-        it "should not add the credentials header" do
-          response = client.get("/inheritence")
-          response.headers["Access-Control-Allow-Credentials"]?.should be_nil
-        end
-
-        it "should add the credentials header" do
-          response = client.get("/inheritence")
-          response.headers["Access-Control-Expose-Headers"]?.should eq "DEFAULT1_EH,DEFAULT2_EH"
-        end
-
-        it "should not add the allow methods header" do
-          response = client.get("/inheritence")
-          response.headers["Access-Control-Allow-Methods"]?.should be_nil
-        end
-
-        it "should not add the allow headers header" do
-          response = client.get("/inheritence")
-          response.headers["Access-Control-Allow-Headers"]?.should be_nil
-        end
-
-        it "should not add the max age header" do
-          response = client.get("/inheritence")
-          response.headers["Access-Control-Max-Age"]?.should be_nil
-        end
-
-        it "should return the correct response" do
-          response = client.get("/inheritence")
-          response.body.should eq "\"inheritence\""
-        end
-      end
-
-      describe "with a disable overload" do
-        it "should not add the allow origin header" do
-          response = client.get("/inheritence_overload")
-          response.headers["Access-Control-Allow-Origin"]?.should be_nil
-          response.headers["Vary"]?.should be_nil
-        end
-
-        it "should not add the credentials header" do
-          response = client.get("/inheritence_overload")
-          response.headers["Access-Control-Allow-Credentials"]?.should be_nil
-        end
-
-        it "should not add the credentials header" do
-          response = client.get("/inheritence_overload")
-          response.headers["Access-Control-Expose-Headers"]?.should be_nil
-        end
-
-        it "should not add the allow methods header" do
-          response = client.get("/inheritence_overload")
-          response.headers["Access-Control-Allow-Methods"]?.should be_nil
-        end
-
-        it "should not add the allow headers header" do
-          response = client.get("/inheritence_overload")
-          response.headers["Access-Control-Allow-Headers"]?.should be_nil
-        end
-
-        it "should not add the max age header" do
-          response = client.get("/inheritence_overload")
-          response.headers["Access-Control-Max-Age"]?.should be_nil
-        end
-
-        it "should return the correct response" do
-          response = client.get("/inheritence_overload")
-          response.body.should eq "\"inheritence_overload\""
-        end
+        response = CLIENT.get("/inheritence_overload")
+        response.body.should eq "\"inheritence_overload\""
       end
     end
   end

--- a/spec/routing/exceptions_spec.cr
+++ b/spec/routing/exceptions_spec.cr
@@ -1,9 +1,10 @@
 require "./routing_spec_helper"
 
-do_with_config do |client|
-  describe Athena::Routing::Exceptions do
-    describe Athena::Routing::Exceptions::AthenaException do
-      {% for exception, index in Athena::Routing::Exceptions::AthenaException.subclasses %}
+describe Athena::Routing::Exceptions do
+  do_with_config
+
+  describe Athena::Routing::Exceptions::AthenaException do
+    {% for exception, index in Athena::Routing::Exceptions::AthenaException.subclasses %}
     {% code = Athena::Routing::Exceptions::COMMON_EXCEPTIONS.keys[index] %}
     {% message = Athena::Routing::Exceptions::COMMON_EXCEPTIONS.values[index] %}
 
@@ -26,33 +27,32 @@ do_with_config do |client|
       end
     end
   {% end %}
-    end
+  end
 
-    describe ".handle_exception" do
-      describe "for a controller that has a custom handler defined" do
-        describe "that handles the given error" do
-          it "should use that handler" do
-            response = client.get("/exception/custom")
-            response.status_code.should eq 666
-            response.body.should eq %({"code": 666, "message": "Division by 0"})
-          end
-        end
-
-        describe "that does not handle the given error" do
-          it "should use use the default handler" do
-            response = client.get("/exception/no_match")
-            response.status.should eq HTTP::Status::INTERNAL_SERVER_ERROR
-            response.body.should eq %({"code": 500, "message": "Internal Server Error"})
-          end
+  describe ".handle_exception" do
+    describe "for a controller that has a custom handler defined" do
+      describe "that handles the given error" do
+        it "should use that handler" do
+          response = CLIENT.get("/exception/custom")
+          response.status_code.should eq 666
+          response.body.should eq %({"code": 666, "message": "Division by 0"})
         end
       end
 
-      describe "for a controller that does not have custom handler defined" do
+      describe "that does not handle the given error" do
         it "should use use the default handler" do
-          response = client.get("/exception/default")
+          response = CLIENT.get("/exception/no_match")
           response.status.should eq HTTP::Status::INTERNAL_SERVER_ERROR
           response.body.should eq %({"code": 500, "message": "Internal Server Error"})
         end
+      end
+    end
+
+    describe "for a controller that does not have custom handler defined" do
+      it "should use use the default handler" do
+        response = CLIENT.get("/exception/default")
+        response.status.should eq HTTP::Status::INTERNAL_SERVER_ERROR
+        response.body.should eq %({"code": 500, "message": "Internal Server Error"})
       end
     end
   end

--- a/spec/routing/logging_spec.cr
+++ b/spec/routing/logging_spec.cr
@@ -49,7 +49,9 @@ module Athena
       end
     end
 
-    do_with_config do |client|
+    describe "exception handling" do
+      do_with_config
+
       describe "when a 500 occurs" do
         it "should log the proper messages" do
           handler = Crylog::Handlers::TestHandler.new
@@ -60,7 +62,7 @@ module Athena
             end
           end
 
-          client.get("/exception/default").status.should eq HTTP::Status::INTERNAL_SERVER_ERROR
+          CLIENT.get("/exception/default").status.should eq HTTP::Status::INTERNAL_SERVER_ERROR
           handler.messages.size.should eq 2
 
           handler.messages[0].formatted.should match /\[#{TIME_REGEX}\] main.INFO: Matched route 'get_default_exception' {"path":"\/exception\/default","method":"GET","remote_address":".*","version":"HTTP\/1\.1","length":null}/
@@ -78,14 +80,13 @@ module Athena
             end
           end
 
-          client.post("/users", body: %({"age":-12}), headers: HTTP::Headers{"content-type" => "application/json"}).status.should eq HTTP::Status::BAD_REQUEST
+          CLIENT.post("/users", body: %({"age":-12}), headers: HTTP::Headers{"content-type" => "application/json"}).status.should eq HTTP::Status::BAD_REQUEST
           handler.messages.size.should eq 2
 
           handler.messages[0].formatted.should match /\[#{TIME_REGEX}\] main.INFO: Matched route 'new_user' {"path":"\/users","method":"POST","remote_address":".*","version":"HTTP\/1\.1","length":11}/
           handler.messages[1].formatted.should match /\[#{TIME_REGEX}\] main.NOTICE: Validation tests failed: `'age' should be greater than 0`\./
         end
       end
-      client.get("/int32/1.00")
 
       describe Athena::Routing::Exceptions::AthenaException do
         it "should log the proper messages" do
@@ -97,7 +98,7 @@ module Athena
             end
           end
 
-          client.get("/users/34").status.should eq HTTP::Status::NOT_FOUND
+          CLIENT.get("/users/34").status.should eq HTTP::Status::NOT_FOUND
           handler.messages.size.should eq 2
 
           handler.messages[0].formatted.should match /\[#{TIME_REGEX}\] main.INFO: Matched route 'get_user' {"path":"\/users\/34","method":"GET","remote_address":".*","version":"HTTP\/1\.1","length":null}/
@@ -115,7 +116,7 @@ module Athena
             end
           end
 
-          client.get("/int32/1.00").status.should eq HTTP::Status::BAD_REQUEST
+          CLIENT.get("/int32/1.00").status.should eq HTTP::Status::BAD_REQUEST
           handler.messages.size.should eq 2
 
           handler.messages[0].formatted.should match /\[#{TIME_REGEX}\] main.INFO: Matched route 'int32' {"path":"\/int32\/1.00","method":"GET","remote_address":".*","version":"HTTP\/1\.1","length":null}/
@@ -134,7 +135,7 @@ module Athena
               end
             end
 
-            client.post("/users", body: %({"age": true}), headers: HTTP::Headers{"content-type" => "application/json"}).status.should eq HTTP::Status::BAD_REQUEST
+            CLIENT.post("/users", body: %({"age": true}), headers: HTTP::Headers{"content-type" => "application/json"}).status.should eq HTTP::Status::BAD_REQUEST
             handler.messages.size.should eq 2
 
             handler.messages[0].formatted.should match /\[#{TIME_REGEX}\] main.INFO: Matched route 'new_user' {"path":"\/users","method":"POST","remote_address":".*","version":"HTTP\/1\.1","length":13}/
@@ -152,7 +153,7 @@ module Athena
               end
             end
 
-            client.post("/users", body: %({"id": "123","age": 100}), headers: HTTP::Headers{"content-type" => "application/json"}).status.should eq HTTP::Status::BAD_REQUEST
+            CLIENT.post("/users", body: %({"id": "123","age": 100}), headers: HTTP::Headers{"content-type" => "application/json"}).status.should eq HTTP::Status::BAD_REQUEST
             handler.messages.size.should eq 2
 
             handler.messages[0].formatted.should match /\[#{TIME_REGEX}\] main.INFO: Matched route 'new_user' {"path":"\/users","method":"POST","remote_address":".*","version":"HTTP\/1\.1","length":24}/
@@ -170,7 +171,7 @@ module Athena
               end
             end
 
-            client.post("/users/string", body: %({id: "123","age": 100}), headers: HTTP::Headers{"content-type" => "application/json"}).status.should eq HTTP::Status::BAD_REQUEST
+            CLIENT.post("/users/string", body: %({id: "123","age": 100}), headers: HTTP::Headers{"content-type" => "application/json"}).status.should eq HTTP::Status::BAD_REQUEST
             handler.messages.size.should eq 2
 
             handler.messages[0].formatted.should match /\[#{TIME_REGEX}\] main.INFO: Matched route 'new_string_user' {"path":"\/users\/string","method":"POST","remote_address":".*","version":"HTTP\/1\.1","length":22}/

--- a/spec/routing/param_converter_spec.cr
+++ b/spec/routing/param_converter_spec.cr
@@ -1,108 +1,108 @@
 require "./routing_spec_helper"
 
-do_with_config do |client|
-  describe Athena::Routing::ParamConverter do
-    describe "Exists" do
-      it "resolves a record that exists" do
-        client.get("/users/17").body.should eq %({"id":17,"age":123})
-      end
+describe Athena::Routing::ParamConverter do
+  do_with_config
 
-      it "resolves a record that exists with a String PK" do
-        client.get("/users/str/71").body.should eq %({"id":71,"age":321})
-      end
+  describe "Exists" do
+    it "resolves a record that exists" do
+      CLIENT.get("/users/17").body.should eq %({"id":17,"age":123})
+    end
 
-      it "returns correct error if the record does not exist" do
-        response = client.get("/users/34")
-        response.body.should eq %({"code":404,"message":"An item with the provided ID could not be found."})
-        response.status.should eq HTTP::Status::NOT_FOUND
-      end
+    it "resolves a record that exists with a String PK" do
+      CLIENT.get("/users/str/71").body.should eq %({"id":71,"age":321})
+    end
 
-      it "resolves a record that has the characters '_id' in it" do
-        client.get("/article/17").body.should eq %({"id":17,"title":"Int"})
-      end
+    it "returns correct error if the record does not exist" do
+      response = CLIENT.get("/users/34")
+      response.body.should eq %({"code":404,"message":"An item with the provided ID could not be found."})
+      response.status.should eq HTTP::Status::NOT_FOUND
+    end
 
-      describe "with two Exists converters" do
-        it "resolves two records" do
-          client.get("/users/17/articles/17").body.should eq "\"123 Int\""
-        end
+    it "resolves a record that has the characters '_id' in it" do
+      CLIENT.get("/article/17").body.should eq %({"id":17,"title":"Int"})
+    end
+
+    describe "with two Exists converters" do
+      it "resolves two records" do
+        CLIENT.get("/users/17/articles/17").body.should eq "\"123 Int\""
+      end
+    end
+  end
+
+  describe "RequestBody" do
+    describe "valid new model" do
+      it "should parse an obj from request body" do
+        CLIENT.post("/users", body: %({"age":99}), headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq %({"id":12,"age":99})
       end
     end
 
-    describe "RequestBody" do
-      describe "valid new model" do
-        it "should parse an obj from request body" do
-          client.post("/users", body: %({"age":99}), headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq %({"id":12,"age":99})
-        end
+    describe "valid existing model" do
+      it "should parse an obj from request body" do
+        CLIENT.put("/users", body: %({"id":17,"age":99}), headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq %({"id":17,"age":99})
       end
+    end
 
-      describe "valid existing model" do
-        it "should parse an obj from request body" do
-          client.put("/users", body: %({"id":17,"age":99}), headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq %({"id":17,"age":99})
-        end
+    describe "invalid model" do
+      it "should return the validation test failed json object" do
+        response = CLIENT.post("/users", body: %({"age":-12}), headers: HTTP::Headers{"content-type" => "application/json"})
+        response.body.should eq %({"code":400,"message":"Validation tests failed","errors":["'age' should be greater than 0"]})
+        response.status.should eq HTTP::Status::BAD_REQUEST
       end
+    end
 
-      describe "invalid model" do
-        it "should return the validation test failed json object" do
-          response = client.post("/users", body: %({"age":-12}), headers: HTTP::Headers{"content-type" => "application/json"})
-          response.body.should eq %({"code":400,"message":"Validation tests failed","errors":["'age' should be greater than 0"]})
+    describe "invalid param" do
+      describe "Int32 as String" do
+        it "should return the invalid param json object" do
+          response = CLIENT.post("/users", body: %({"age": "foo"}), headers: HTTP::Headers{"content-type" => "application/json"})
+          response.body.should eq %({"code": 400, "message": "Expected 'age' to be Int but got String"})
           response.status.should eq HTTP::Status::BAD_REQUEST
         end
       end
 
-      describe "invalid param" do
-        describe "Int32 as String" do
-          it "should return the invalid param json object" do
-            response = client.post("/users", body: %({"age": "foo"}), headers: HTTP::Headers{"content-type" => "application/json"})
-            response.body.should eq %({"code": 400, "message": "Expected 'age' to be Int but got String"})
-            response.status.should eq HTTP::Status::BAD_REQUEST
-          end
-        end
-
-        describe "Int32 as Bool" do
-          it "should return the invalid param json object" do
-            response = client.post("/users", body: %({"age": true}), headers: HTTP::Headers{"content-type" => "application/json"})
-            response.body.should eq %({"code": 400, "message": "Expected 'age' to be Int but got Bool"})
-            response.status.should eq HTTP::Status::BAD_REQUEST
-          end
-        end
-
-        describe "Int32 as null" do
-          it "should return the invalid param json object" do
-            response = client.post("/users", body: %({"age": null}), headers: HTTP::Headers{"content-type" => "application/json"})
-            response.body.should eq %({"code": 400, "message": "Expected 'age' to be Int but got Null"})
-            response.status.should eq HTTP::Status::BAD_REQUEST
-          end
-        end
-
-        describe "Int64? as String" do
-          it "should return the invalid param json object" do
-            response = client.post("/users", body: %({"id": "123","age": 100}), headers: HTTP::Headers{"content-type" => "application/json"})
-            response.body.should eq %({"code": 400, "message": "Couldn't parse Int64 | Nil from '"123"'"})
-            response.status.should eq HTTP::Status::BAD_REQUEST
-          end
-        end
-
-        describe "Int64? as Bool" do
-          it "should return the invalid param json object" do
-            response = client.post("/users", body: %({"id": true,"age": 100}), headers: HTTP::Headers{"content-type" => "application/json"})
-            response.body.should eq %({"code": 400, "message": "Couldn't parse Int64 | Nil from 'true'"})
-            response.status.should eq HTTP::Status::BAD_REQUEST
-          end
+      describe "Int32 as Bool" do
+        it "should return the invalid param json object" do
+          response = CLIENT.post("/users", body: %({"age": true}), headers: HTTP::Headers{"content-type" => "application/json"})
+          response.body.should eq %({"code": 400, "message": "Expected 'age' to be Int but got Bool"})
+          response.status.should eq HTTP::Status::BAD_REQUEST
         end
       end
 
-      describe "with an Exists and RequestBody converter" do
-        it "should resolve correctly" do
-          client.post("/users/articles/17", body: %({"age":90210}), headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "\"90210 Int\""
+      describe "Int32 as null" do
+        it "should return the invalid param json object" do
+          response = CLIENT.post("/users", body: %({"age": null}), headers: HTTP::Headers{"content-type" => "application/json"})
+          response.body.should eq %({"code": 400, "message": "Expected 'age' to be Int but got Null"})
+          response.status.should eq HTTP::Status::BAD_REQUEST
+        end
+      end
+
+      describe "Int64? as String" do
+        it "should return the invalid param json object" do
+          response = CLIENT.post("/users", body: %({"id": "123","age": 100}), headers: HTTP::Headers{"content-type" => "application/json"})
+          response.body.should eq %({"code": 400, "message": "Couldn't parse Int64 | Nil from '"123"'"})
+          response.status.should eq HTTP::Status::BAD_REQUEST
+        end
+      end
+
+      describe "Int64? as Bool" do
+        it "should return the invalid param json object" do
+          response = CLIENT.post("/users", body: %({"id": true,"age": 100}), headers: HTTP::Headers{"content-type" => "application/json"})
+          response.body.should eq %({"code": 400, "message": "Couldn't parse Int64 | Nil from 'true'"})
+          response.status.should eq HTTP::Status::BAD_REQUEST
         end
       end
     end
 
-    describe "FormData" do
-      describe "valid new model" do
-        it "should parse an obj from request body" do
-          client.post("/users/form", body: %(age=1&id=99), headers: HTTP::Headers{"content-type" => "application/x-www-form-urlencoded"}).body.should eq %({"id":99,"age":1})
-        end
+    describe "with an Exists and RequestBody converter" do
+      it "should resolve correctly" do
+        CLIENT.post("/users/articles/17", body: %({"age":90210}), headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "\"90210 Int\""
+      end
+    end
+  end
+
+  describe "FormData" do
+    describe "valid new model" do
+      it "should parse an obj from request body" do
+        CLIENT.post("/users/form", body: %(age=1&id=99), headers: HTTP::Headers{"content-type" => "application/x-www-form-urlencoded"}).body.should eq %({"id":99,"age":1})
       end
     end
   end

--- a/spec/routing/prefix_spec.cr
+++ b/spec/routing/prefix_spec.cr
@@ -1,22 +1,22 @@
 require "./routing_spec_helper"
 
-do_with_config do |client|
-  describe Athena::Routing do
+describe Athena::Routing do
+  do_with_config
+
+  it "should route correctly" do
+    CLIENT.get("/calendar/events").body.should eq "\"events\""
+    CLIENT.get("/calendar/external").body.should eq "\"calendars\""
+  end
+
+  describe "with a path param" do
     it "should route correctly" do
-      client.get("/calendar/events").body.should eq "\"events\""
-      client.get("/calendar/external").body.should eq "\"calendars\""
+      CLIENT.get("/calendar/external/99999999").body.should eq "99999999"
     end
+  end
 
-    describe "with a path param" do
-      it "should route correctly" do
-        client.get("/calendar/external/99999999").body.should eq "99999999"
-      end
-    end
-
-    describe "that has parent prefixes" do
-      it "should route correctly" do
-        client.get("/calendar/athena/child1").body.should eq "\"child1 + athena\""
-      end
+  describe "that has parent prefixes" do
+    it "should route correctly" do
+      CLIENT.get("/calendar/athena/child1").body.should eq "\"child1 + athena\""
     end
   end
 end

--- a/spec/routing/query_param_spec.cr
+++ b/spec/routing/query_param_spec.cr
@@ -1,101 +1,101 @@
 require "./routing_spec_helper"
 
-do_with_config do |client|
-  describe "QueryParams" do
-    describe "when it is required" do
-      describe "with a constraint" do
-        describe "that is not provided " do
-          it "should raise proper error" do
-            response = client.get("/get/query_param_constraint_required")
-            response.body.should eq %({"code":400,"message":"Required query param 'time' was not supplied."})
-            response.status.should eq HTTP::Status::BAD_REQUEST
-          end
-        end
+describe Athena::Routing::Parameters::QueryParameter do
+  do_with_config
 
-        describe "that is supplied" do
-          it "should return the value" do
-            client.get("/get/query_param_constraint_required?time=1:2:3").body.should eq "\"1:2:3\""
-          end
-        end
-
-        describe "that is supplied but doesn't match" do
-          it "should raise proper error" do
-            response = client.get("/get/query_param_constraint_required?time=1:a:3")
-            response.body.should eq %q({"code":400,"message":"Expected query param 'time' to match '(?-imsx:\\d:\\d:\\d)' but got '1:a:3'"})
-            response.status.should eq HTTP::Status::BAD_REQUEST
-          end
+  describe "when it is required" do
+    describe "with a constraint" do
+      describe "that is not provided " do
+        it "should raise proper error" do
+          response = CLIENT.get("/get/query_param_constraint_required")
+          response.body.should eq %({"code":400,"message":"Required query param 'time' was not supplied."})
+          response.status.should eq HTTP::Status::BAD_REQUEST
         end
       end
 
-      describe "without a constraint" do
-        describe "that is not provided " do
-          it "should raise proper error" do
-            response = client.get("/get/query_param_required")
-            response.body.should eq %({"code":400,"message":"Required query param 'time' was not supplied."})
-            response.status.should eq HTTP::Status::BAD_REQUEST
-          end
+      describe "that is supplied" do
+        it "should return the value" do
+          CLIENT.get("/get/query_param_constraint_required?time=1:2:3").body.should eq "\"1:2:3\""
         end
+      end
 
-        describe "that is supplied" do
-          it "should return the value" do
-            client.get("/get/query_param_required?time=1:2:3").body.should eq "\"1:2:3\""
-          end
+      describe "that is supplied but doesn't match" do
+        it "should raise proper error" do
+          response = CLIENT.get("/get/query_param_constraint_required?time=1:a:3")
+          response.body.should eq %q({"code":400,"message":"Expected query param 'time' to match '(?-imsx:\\d:\\d:\\d)' but got '1:a:3'"})
+          response.status.should eq HTTP::Status::BAD_REQUEST
         end
       end
     end
 
-    describe "when it is optional" do
-      describe "with a constraint" do
-        describe "that is not provided " do
-          it "should return nil" do
-            client.get("/get/query_params_constraint_optional").body.should eq "null"
-          end
-        end
-
-        describe "that is supplied" do
-          it "should return the value" do
-            client.get("/get/query_params_constraint_optional?time=1:2:3").body.should eq "\"1:2:3\""
-          end
-        end
-
-        describe "that is supplied but doesn't match" do
-          it "should return nil" do
-            client.get("/get/query_params_constraint_optional").body.should eq "null"
-          end
-        end
-
-        describe "that is not supplied but has a default value" do
-          it "should return the default value" do
-            client.get("/get/query_params_constraint_optional_default").body.should eq "\"foo\""
-          end
+    describe "without a constraint" do
+      describe "that is not provided " do
+        it "should raise proper error" do
+          response = CLIENT.get("/get/query_param_required")
+          response.body.should eq %({"code":400,"message":"Required query param 'time' was not supplied."})
+          response.status.should eq HTTP::Status::BAD_REQUEST
         end
       end
 
-      describe "without a constraint" do
-        describe "that is not provided " do
-          it "should return nil" do
-            client.get("/get/query_params_optional").body.should eq "null"
-          end
+      describe "that is supplied" do
+        it "should return the value" do
+          CLIENT.get("/get/query_param_required?time=1:2:3").body.should eq "\"1:2:3\""
         end
+      end
+    end
+  end
 
-        describe "that is supplied" do
-          it "should return the value" do
-            client.get("/get/query_params_optional?time=1:2:3").body.should eq "\"1:2:3\""
-          end
+  describe "when it is optional" do
+    describe "with a constraint" do
+      describe "that is not provided " do
+        it "should return nil" do
+          CLIENT.get("/get/query_params_constraint_optional").body.should eq "null"
         end
       end
 
-      describe "with a default value" do
-        describe "that is not provided " do
-          it "should return the default value" do
-            client.get("/get/query_params_optional_default").body.should eq "999"
-          end
+      describe "that is supplied" do
+        it "should return the value" do
+          CLIENT.get("/get/query_params_constraint_optional?time=1:2:3").body.should eq "\"1:2:3\""
         end
+      end
 
-        describe "that is supplied" do
-          it "should return the value" do
-            client.get("/get/query_params_optional_default?page=13").body.should eq "13"
-          end
+      describe "that is supplied but doesn't match" do
+        it "should return nil" do
+          CLIENT.get("/get/query_params_constraint_optional").body.should eq "null"
+        end
+      end
+
+      describe "that is not supplied but has a default value" do
+        it "should return the default value" do
+          CLIENT.get("/get/query_params_constraint_optional_default").body.should eq "\"foo\""
+        end
+      end
+    end
+
+    describe "without a constraint" do
+      describe "that is not provided " do
+        it "should return nil" do
+          CLIENT.get("/get/query_params_optional").body.should eq "null"
+        end
+      end
+
+      describe "that is supplied" do
+        it "should return the value" do
+          CLIENT.get("/get/query_params_optional?time=1:2:3").body.should eq "\"1:2:3\""
+        end
+      end
+    end
+
+    describe "with a default value" do
+      describe "that is not provided " do
+        it "should return the default value" do
+          CLIENT.get("/get/query_params_optional_default").body.should eq "999"
+        end
+      end
+
+      describe "that is supplied" do
+        it "should return the value" do
+          CLIENT.get("/get/query_params_optional_default?page=13").body.should eq "13"
         end
       end
     end

--- a/spec/routing/renderer_spec.cr
+++ b/spec/routing/renderer_spec.cr
@@ -1,47 +1,47 @@
 require "./routing_spec_helper"
 
-do_with_config do |client|
-  describe Athena::Routing::Renderers do
-    describe "custom" do
+describe Athena::Routing::Renderers do
+  do_with_config
+
+  describe "custom" do
+    it "should render correctly" do
+      response = CLIENT.get("/users/custom/17")
+      response.body.should eq "<?xml version=\"1.0\"?>\n<user id=\"17\"><age>123</age></user>\n"
+      response.headers.includes_word?("Content-Type", "X-CUSTOM-TYPE").should be_true
+    end
+  end
+
+  describe "ECR" do
+    describe ".def_to_s" do
       it "should render correctly" do
-        response = client.get("/users/custom/17")
-        response.body.should eq "<?xml version=\"1.0\"?>\n<user id=\"17\"><age>123</age></user>\n"
-        response.headers.includes_word?("Content-Type", "X-CUSTOM-TYPE").should be_true
+        response = CLIENT.get("/users/ecr/17")
+        response.body.should eq "User 17 is 123 years old."
+        response.headers["Content-Type"].should eq "text/html; charset=utf-8"
       end
     end
 
-    describe "ECR" do
-      describe ".def_to_s" do
-        it "should render correctly" do
-          response = client.get("/users/ecr/17")
-          response.body.should eq "User 17 is 123 years old."
-          response.headers["Content-Type"].should eq "text/html; charset=utf-8"
-        end
-      end
-
-      describe ".render" do
-        it "should render correctly" do
-          response = client.get("/ecr_html")
-          response.body.should eq "<!DOCTYPE html>\n<html>\n<body>\n\n<h1>Hello John!</h1>\n\n<p>My first paragraph.</p>\n\n</body>\n</html>"
-          response.headers["Content-Type"].should eq "text/html; charset=utf-8"
-        end
+    describe ".render" do
+      it "should render correctly" do
+        response = CLIENT.get("/ecr_html")
+        response.body.should eq "<!DOCTYPE html>\n<html>\n<body>\n\n<h1>Hello John!</h1>\n\n<p>My first paragraph.</p>\n\n</body>\n</html>"
+        response.headers["Content-Type"].should eq "text/html; charset=utf-8"
       end
     end
+  end
 
-    describe "YAML" do
-      it "should render correctly" do
-        response = client.get("/users/yaml/17")
-        response.body.should eq "---\nid: 17\nage: 123\n"
-        response.headers["Content-Type"].should eq "text/x-yaml; charset=utf-8"
-      end
+  describe "YAML" do
+    it "should render correctly" do
+      response = CLIENT.get("/users/yaml/17")
+      response.body.should eq "---\nid: 17\nage: 123\n"
+      response.headers["Content-Type"].should eq "text/x-yaml; charset=utf-8"
     end
+  end
 
-    describe "JSON" do
-      it "should render correctly" do
-        response = client.get("/users/17")
-        response.body.should eq %({"id":17,"age":123})
-        response.headers["Content-Type"].should eq "application/json; charset=utf-8"
-      end
+  describe "JSON" do
+    it "should render correctly" do
+      response = CLIENT.get("/users/17")
+      response.body.should eq %({"id":17,"age":123})
+      response.headers["Content-Type"].should eq "application/json; charset=utf-8"
     end
   end
 end

--- a/spec/routing/routing_spec.cr
+++ b/spec/routing/routing_spec.cr
@@ -1,146 +1,146 @@
 require "./routing_spec_helper"
 
-do_with_config do |client|
-  describe Athena::Routing do
-    describe ".run" do
-      describe "with custom handlers" do
-        describe "when missing the action handler" do
-          it "should throw an exception" do
-            expect_raises Exception, "Handlers must include 'Athena::Routing::Handlers::ActionHandler'." do
-              Athena::Routing.run(handlers: [Athena::Routing::Handlers::CorsHandler.new] of HTTP::Handler)
-            end
+describe Athena::Routing do
+  do_with_config
+
+  describe ".run" do
+    describe "with custom handlers" do
+      describe "when missing the action handler" do
+        it "should throw an exception" do
+          expect_raises Exception, "Handlers must include 'Athena::Routing::Handlers::ActionHandler'." do
+            Athena::Routing.run(handlers: [Athena::Routing::Handlers::CorsHandler.new] of HTTP::Handler)
           end
         end
       end
     end
+  end
 
-    describe "with no params" do
-      describe "GET" do
-        it "works" do
-          client.get("/noParamsGet").body.should eq "\"foobar\""
-        end
-      end
-
-      describe "POST" do
-        describe "with only post body" do
-          describe "that is optional" do
-            it "should return normally" do
-              client.post("/noParamsPostOptional").body.should eq "\"foobar\""
-            end
-          end
-
-          describe "that is required" do
-            it "returns correct error" do
-              response = client.post("/noParamsPostRequired")
-              response.body.should eq %({"code":400,"message":"Request body was not supplied."})
-              response.status.should eq HTTP::Status::BAD_REQUEST
-            end
-          end
-        end
-      end
-    end
-
-    describe "with two params" do
+  describe "with no params" do
+    describe "GET" do
       it "works" do
-        client.get("/double/1000/9000").body.should eq "10000"
-        client.post("/double/750", body: "250", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "1000"
+        CLIENT.get("/noParamsGet").body.should eq "\"foobar\""
       end
     end
 
-    describe "that throws a custom exception" do
-      it "gets rendered correctly" do
-        response = client.get("/get/custom_error")
-        response.body.should eq %({"code":418,"message":"teapot"})
-        response.status.should eq HTTP::Status::IM_A_TEAPOT
+    describe "POST" do
+      describe "with only post body" do
+        describe "that is optional" do
+          it "should return normally" do
+            CLIENT.post("/noParamsPostOptional").body.should eq "\"foobar\""
+          end
+        end
+
+        describe "that is required" do
+          it "returns correct error" do
+            response = CLIENT.post("/noParamsPostRequired")
+            response.body.should eq %({"code":400,"message":"Request body was not supplied."})
+            response.status.should eq HTTP::Status::BAD_REQUEST
+          end
+        end
+      end
+    end
+  end
+
+  describe "with two params" do
+    it "works" do
+      CLIENT.get("/double/1000/9000").body.should eq "10000"
+      CLIENT.post("/double/750", body: "250", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "1000"
+    end
+  end
+
+  describe "that throws a custom exception" do
+    it "gets rendered correctly" do
+      response = CLIENT.get("/get/custom_error")
+      response.body.should eq %({"code":418,"message":"teapot"})
+      response.status.should eq HTTP::Status::IM_A_TEAPOT
+    end
+  end
+
+  describe "with a route that doesnt exist" do
+    it "returns correct error" do
+      response = CLIENT.get("/dsfdsf")
+      response.body.should eq %({"code":404,"message":"No route found for 'GET /dsfdsf'"})
+      response.status.should eq HTTP::Status::NOT_FOUND
+
+      response = CLIENT.post("/dsfdsf")
+      response.body.should eq %({"code":404,"message":"No route found for 'POST /dsfdsf'"})
+      response.status.should eq HTTP::Status::NOT_FOUND
+    end
+  end
+
+  describe "with a route that has a default value" do
+    describe "GET" do
+      it "returns the provided value" do
+        CLIENT.get("/posts/123").body.should eq "123"
+      end
+
+      it "returns the default value" do
+        CLIENT.get("/posts/").body.should eq "99"
+      end
+
+      it "does not conflict" do
+        CLIENT.get("/posts/foo/bvar").body.should eq "\"foo\""
       end
     end
 
-    describe "with a route that doesnt exist" do
+    describe "POST" do
+      it "adds using the default value" do
+        CLIENT.post("/posts/99", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "100"
+      end
+
+      it "adds using the provided value" do
+        CLIENT.post("/posts/99", body: "100", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "199"
+      end
+    end
+  end
+
+  describe "invalid Content-Type" do
+    describe "not supported" do
       it "returns correct error" do
-        response = client.get("/dsfdsf")
-        response.body.should eq %({"code":404,"message":"No route found for 'GET /dsfdsf'"})
-        response.status.should eq HTTP::Status::NOT_FOUND
-
-        response = client.post("/dsfdsf")
-        response.body.should eq %({"code":404,"message":"No route found for 'POST /dsfdsf'"})
-        response.status.should eq HTTP::Status::NOT_FOUND
+        CLIENT.post("/posts/99", body: "100", headers: HTTP::Headers{"content-type" => "application/foo"}).body.should eq %({"code":415,"message":"Invalid Content-Type: 'application/foo'"})
       end
     end
 
-    describe "with a route that has a default value" do
-      describe "GET" do
-        it "returns the provided value" do
-          client.get("/posts/123").body.should eq "123"
-        end
-
-        it "returns the default value" do
-          client.get("/posts/").body.should eq "99"
-        end
-
-        it "does not conflict" do
-          client.get("/posts/foo/bvar").body.should eq "\"foo\""
-        end
-      end
-
-      describe "POST" do
-        it "adds using the default value" do
-          client.post("/posts/99", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "100"
-        end
-
-        it "adds using the provided value" do
-          client.post("/posts/99", body: "100", headers: HTTP::Headers{"content-type" => "application/json"}).body.should eq "199"
-        end
+    describe "missing" do
+      it "should default to text/plain" do
+        CLIENT.post("/posts/99", body: "100").body.should eq "199"
       end
     end
+  end
 
-    describe "invalid Content-Type" do
-      describe "not supported" do
-        it "returns correct error" do
-          client.post("/posts/99", body: "100", headers: HTTP::Headers{"content-type" => "application/foo"}).body.should eq %({"code":415,"message":"Invalid Content-Type: 'application/foo'"})
-        end
-      end
-
-      describe "missing" do
-        it "should default to text/plain" do
-          client.post("/posts/99", body: "100").body.should eq "199"
-        end
-      end
+  describe "nil return type" do
+    it "should return 204 no content" do
+      response = CLIENT.get("/get/nil_return")
+      response.status.should eq HTTP::Status::NO_CONTENT
+      response.body.should be_empty
     end
 
-    describe "nil return type" do
-      it "should return 204 no content" do
-        response = client.get("/get/nil_return")
-        response.status.should eq HTTP::Status::NO_CONTENT
+    describe "and the response status was changed in the action" do
+      it "should not use no content" do
+        response = CLIENT.get("/get/nil_return/updated_status")
+        response.status.should eq HTTP::Status::IM_A_TEAPOT
         response.body.should be_empty
       end
-
-      describe "and the response status was changed in the action" do
-        it "should not use no content" do
-          response = client.get("/get/nil_return/updated_status")
-          response.status.should eq HTTP::Status::IM_A_TEAPOT
-          response.body.should be_empty
-        end
-      end
     end
+  end
 
-    describe "#get_request" do
-      it "has access to the request object" do
-        client.get("/get/request").body.should eq "\"/get/request\""
-      end
+  describe "#get_request" do
+    it "has access to the request object" do
+      CLIENT.get("/get/request").body.should eq "\"/get/request\""
     end
+  end
 
-    describe "#get_response" do
-      it "has access to the response object" do
-        client.get("/get/response").headers.includes_word?("Foo", "Bar").should be_true
-      end
+  describe "#get_response" do
+    it "has access to the response object" do
+      CLIENT.get("/get/response").headers.includes_word?("Foo", "Bar").should be_true
     end
+  end
 
-    it "is concurrently safe" do
-      spawn do
-        sleep 1
-        HTTP::Client.get("http://localhost:8888/get/safe?bar").body.should eq %("safe")
-      end
-      client.get("/get/safe?foo").body.should eq "\"safe\""
+  it "is concurrently safe" do
+    spawn do
+      sleep 1
+      HTTP::Client.get("http://localhost:8888/get/safe?bar").body.should eq %("safe")
     end
+    CLIENT.get("/get/safe?foo").body.should eq "\"safe\""
   end
 end

--- a/spec/routing/routing_spec_helper.cr
+++ b/spec/routing/routing_spec_helper.cr
@@ -4,21 +4,24 @@ require "file_utils"
 require "../../src/routing"
 require "./controllers/*"
 
-DEFAULT_CONFIG = "athena.yml"
+CLIENT         = HTTP::Client.new "localhost", 8888
 CORS_CONFIG    = "spec/routing/athena.yml"
+DEFAULT_CONFIG = "athena.yml"
 
 Spec.before_each { ENV["ATHENA_ENV"] = "test" }
 
-# Spawns a server with the given confg file path, runs the block, then stops the server.
-def do_with_config(path : String = DEFAULT_CONFIG, &block : HTTP::Client -> Nil) : Nil
-  ENV["ATHENA_ENV"] = "test"
-  ENV["ATHENA_CONFIG_PATH"] = path
-  client = HTTP::Client.new "localhost", 8888
-  spawn { Athena::Routing.run(8888) }
-  sleep 0.5
-  yield client
-ensure
-  Athena::Routing.stop
+# Spawns a server with the given confg file path, runs the specs in the describe block, then stops the server.
+def do_with_config(path : String = DEFAULT_CONFIG) : Nil
+  around_all do |example|
+    ENV["ATHENA_ENV"] = "test"
+    ENV["ATHENA_CONFIG_PATH"] = path
+    spawn { Athena::Routing.run(8888) }
+    sleep 0.5
+    example.run
+  ensure
+    CLIENT.close # Close the client so each spec file gets its own connection.
+    Athena::Routing.stop
+  end
 end
 
 puts

--- a/spec/routing/static_file_spec.cr
+++ b/spec/routing/static_file_spec.cr
@@ -1,15 +1,15 @@
 require "./routing_spec_helper"
 
-do_with_config do |client|
-  describe "Static files" do
-    pending "should return correct file" do
-      client.get("/test.txt").body.should eq File.read("spec/public/test.txt")
-    end
+describe "Static files" do
+  do_with_config
 
-    it "should 404 if file is missing" do
-      response = client.get("/foo.txt")
-      response.body.should eq %({"code":404,"message":"No route found for 'GET /foo.txt'"})
-      response.status.should eq HTTP::Status::NOT_FOUND
-    end
+  pending "should return correct file" do
+    CLIENT.get("/test.txt").body.should eq File.read("spec/public/test.txt")
+  end
+
+  it "should 404 if file is missing" do
+    response = CLIENT.get("/foo.txt")
+    response.body.should eq %({"code":404,"message":"No route found for 'GET /foo.txt'"})
+    response.status.should eq HTTP::Status::NOT_FOUND
   end
 end

--- a/spec/routing/view_spec.cr
+++ b/spec/routing/view_spec.cr
@@ -1,23 +1,23 @@
 require "./routing_spec_helper"
 
-do_with_config do |client|
-  describe Athena::Routing::View do
-    describe "default group" do
-      it "should serialize correctly" do
-        client.get("/users/17").body.should eq %({"id":17,"age":123})
-      end
-    end
+describe Athena::Routing::View do
+  do_with_config
 
-    describe "admin group" do
-      it "should serialize correctly" do
-        client.get("/admin/users/17").body.should eq %({"password":"monkey"})
-      end
+  describe "default group" do
+    it "should serialize correctly" do
+      CLIENT.get("/users/17").body.should eq %({"id":17,"age":123})
     end
+  end
 
-    describe "admin + default" do
-      it "should serialize correctly" do
-        client.get("/admin/users/17/all").body.should eq %({"id":17,"age":123,"password":"monkey"})
-      end
+  describe "admin group" do
+    it "should serialize correctly" do
+      CLIENT.get("/admin/users/17").body.should eq %({"password":"monkey"})
+    end
+  end
+
+  describe "admin + default" do
+    it "should serialize correctly" do
+      CLIENT.get("/admin/users/17/all").body.should eq %({"id":17,"age":123,"password":"monkey"})
     end
   end
 end

--- a/spec/run_specs.sh
+++ b/spec/run_specs.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Shell script to run specs.
-crystal spec spec/athena_spec.cr --warnings all --error-on-warnings
-crystal spec spec/cli --warnings all --error-on-warnings
-crystal spec spec/config --warnings all --error-on-warnings
-crystal spec spec/dependency_injection --warnings all --error-on-warnings
-crystal spec spec/routing --warnings all --error-on-warnings
+crystal spec spec/athena_spec.cr --order random --error-on-warnings
+crystal spec spec/cli --order random --error-on-warnings
+crystal spec spec/config --order random --error-on-warnings
+crystal spec spec/dependency_injection --order random --error-on-warnings
+crystal spec spec/routing --order random --error-on-warnings

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -23,7 +23,7 @@ module Athena::Cli
 
   # Defines an option parser interface for Athena CLI commands.
   macro register_commands
-    OptionParser.parse! do |parser|
+    OptionParser.parse do |parser|
       parser.banner = "Usage: YOUR_BINARY [arguments]"
       parser.on("-h", "--help", "Show this help") { puts parser; exit }
       parser.on("-l", "--list", "List available commands") { puts Athena::Cli::Registry.to_s; exit }

--- a/src/dependency_injection/service_container.cr
+++ b/src/dependency_injection/service_container.cr
@@ -12,7 +12,7 @@ module Athena::DI
         {% for service in services %}
           {% for service_ann in service.annotations(Athena::DI::Register) %}
             {% key = service_ann[:name] ? service_ann[:name] : service.name.split("::").last.underscore %}
-            private getter {{key.id}} : {{service.id}}
+            getter {{key.id}} : {{service.id}}
           {% end %}
         {% end %}
       {% end %}
@@ -111,11 +111,6 @@ module Athena::DI
         {% end %}
         @tags = {{tagged_services}} of String => Array(String)
       {% end %}
-    end
-
-    # Returns the service with the provided *name*.
-    def get(name : String)
-      internal_get(name) || raise "No service with the name '#{name}' has been registered."
     end
 
     # Returns an array of services of the provided *type*.

--- a/src/dependency_injection/service_container.cr
+++ b/src/dependency_injection/service_container.cr
@@ -12,7 +12,7 @@ module Athena::DI
         {% for service in services %}
           {% for service_ann in service.annotations(Athena::DI::Register) %}
             {% key = service_ann[:name] ? service_ann[:name] : service.name.split("::").last.underscore %}
-            getter {{key.id}} : {{service.id}}
+            {% if service_ann[:public] != true %} private {% end %}getter {{key.id}} : {{service.id}}
           {% end %}
         {% end %}
       {% end %}

--- a/src/di.cr
+++ b/src/di.cr
@@ -5,6 +5,9 @@ class Fiber
   property container : Athena::DI::ServiceContainer { Athena::DI::ServiceContainer.new }
 end
 
+# Convenience alias to make referencing `Athena::DI` types easier.
+alias ADI = Athena::DI
+
 # Dependency Injection module
 #
 # * Adds a service container layer

--- a/src/di.cr
+++ b/src/di.cr
@@ -2,7 +2,7 @@ require "./dependency_injection/service_container"
 
 # :nodoc:
 class Fiber
-  property! container : Athena::DI::ServiceContainer
+  property container : Athena::DI::ServiceContainer { Athena::DI::ServiceContainer.new }
 end
 
 # Dependency Injection module
@@ -51,10 +51,8 @@ module Athena::DI
   abstract class ClassService
   end
 
-  # Returns the container for the current fiber.
-  #
-  # NOTE: By default this is the main fiber, the container would have to be set manually within each child fiber.
-  def self.get_container : Athena::DI::ServiceContainer
+  # Returns the `Athena::DI::ServiceContainer` for the current fiber.
+  def self.container : Athena::DI::ServiceContainer
     Fiber.current.container
   end
 
@@ -66,7 +64,7 @@ module Athena::DI
           def self.new(**args)
             new(
               \{% for arg in method.args %}
-                \{{arg.name.id}}: args[\{{arg.name.symbolize}}]? || Athena::DI.get_container.resolve(\{{arg.restriction.id}}, \{{arg.name.stringify}}),
+                \{{arg.name.id}}: args[\{{arg.name.symbolize}}]? || Athena::DI.container.resolve(\{{arg.restriction.id}}, \{{arg.name.stringify}}),
               \{% end %}
             )
           end
@@ -75,6 +73,3 @@ module Athena::DI
     end
   end
 end
-
-# Set the container on the current (main) fiber so its available project wide from start.
-Fiber.current.container = Athena::DI::ServiceContainer.new if Fiber.current.name == "main"

--- a/src/routing.cr
+++ b/src/routing.cr
@@ -158,8 +158,8 @@ module Athena::Routing
     OnResponse
   end
 
-  # Parent class for all controllers.
-  abstract class Controller
+  # Parent struct for all controllers.
+  abstract struct Controller
     # Exits the request with the given *status_code* and *body*.
     #
     # NOTE: declared on top level namespace but documented here

--- a/src/routing.cr
+++ b/src/routing.cr
@@ -322,7 +322,7 @@ module Athena::Routing
         exit
       end
 
-      puts "Athena is leading the way on #{binding}:#{port} in the #{Athena.environment} environment"
+      Athena.logger.info "Athena is leading the way on #{binding}:#{port} in the #{Athena.environment} environment"
     end
 
     unless @@server.not_nil!.each_address { |_| break true }

--- a/src/routing/handlers/action_handler.cr
+++ b/src/routing/handlers/action_handler.cr
@@ -6,7 +6,7 @@ module Athena::Routing::Handlers
     def call(ctx : HTTP::Server::Context) : Nil
       call_next ctx; return if ctx.request.method == "OPTIONS"
 
-      action = Athena::DI.get_container.get("request_stack").as(RequestStack).action
+      action = Athena::DI.container.request_stack.action
       params = Hash(String, String?).new
 
       # Process action's parameters.

--- a/src/routing/handlers/cors_handler.cr
+++ b/src/routing/handlers/cors_handler.cr
@@ -5,7 +5,7 @@ module Athena::Routing::Handlers
 
     # ameba:disable Metrics/CyclomaticComplexity
     def call(ctx : HTTP::Server::Context) : Nil
-      action = Athena::DI.get_container.get("request_stack").as(RequestStack).action
+      action = Athena::DI.container.request_stack.action
       config = Athena.config
 
       # Run the next handler and return if CORS is globally not enabled, not enabled for a specific controller/action, or strategy is whitelist and cors_group is nil.

--- a/src/routing/handlers/route_handler.cr
+++ b/src/routing/handlers/route_handler.cr
@@ -171,7 +171,10 @@ module Athena::Routing::Handlers
           {% renderer = view_ann && view_ann[:renderer] ? view_ann[:renderer] : "Athena::Routing::Renderers::JSONRenderer".id %}
 
             %action = ->(ctx : HTTP::Server::Context, vals : Hash(String, String?)) do
-              instance = {{klass.id}}.new
+              {% concrete_klass = klass.abstract? ? klass.all_subclasses.find { |sc| !sc.abstract? } : klass %}
+              {% raise "#{klass.name} does not have any non abstract children." unless concrete_klass %}
+
+              instance = {{concrete_klass.id}}.new
               # If there are no args, just call the action.  Otherwise build out an array of values to pass to the action.
               {% unless m.args.empty? %}
                 arr = Array(Union({{arg_types.splat}}, Nil)).new

--- a/src/routing/handlers/route_handler.cr
+++ b/src/routing/handlers/route_handler.cr
@@ -234,7 +234,7 @@ module Athena::Routing::Handlers
       Athena.logger.info "Matched route '#{action.method}'", Crylog::LogContext{"path" => ctx.request.resource, "method" => ctx.request.method, "remote_address" => ctx.request.remote_address, "version" => ctx.request.version, "length" => ctx.request.content_length}
 
       # DI isn't initialized until this point, so get the request_stack directly from the container after setting the container
-      request_stack = Athena::DI.get_container.get("request_stack").as(RequestStack)
+      request_stack = Athena::DI.container.request_stack
 
       # Push the new request and action into the stack
       request_stack.requests << ctx

--- a/src/routing/request_stack.cr
+++ b/src/routing/request_stack.cr
@@ -1,5 +1,5 @@
 module Athena::Routing
-  @[Athena::DI::Register]
+  @[Athena::DI::Register(public: true)]
   # Contains the current request, response, and action.
   # Allows for them to be injected into other classes via DI.
   class RequestStack < Athena::DI::ClassService

--- a/src/routing/request_stack.cr
+++ b/src/routing/request_stack.cr
@@ -4,10 +4,10 @@ module Athena::Routing
   # Allows for them to be injected into other classes via DI.
   class RequestStack < Athena::DI::ClassService
     # :nodoc:
-    getter requests = [] of HTTP::Server::Context
+    getter requests = Deque(HTTP::Server::Context).new
 
     # :nodoc:
-    getter actions = [] of Athena::Routing::Action
+    getter actions = Deque(Athena::Routing::Action).new
 
     # Returns the current request.
     def request : HTTP::Request


### PR DESCRIPTION
**NOTE:** Specs will fail until Crystal `0.32.0` is out, nightly CI passes.

## CLI
* Change `parse!` to `parse` to fix a `0.31.0` breaking change

## DI
* Adds a convenience `ADI` alias to make accessing `Athena::DI` types easier.
* Renames the function to get the container from `.get_container` to `.container`.
* Lazily initializes the container
  * Removes need to set it explicitly on the main fiber.
* Remove `#get` in favor of ivars and getter methods
  * Allows for `Athena::DI.container.my_service` vs `Athena::DI.container.get("my_service").as(MyService)`
  * Also turns unregistered services into a compile error vs runtime error
* Introduces concept of private and public services
  * Services are private by default and cannot be accessed directly; they must be accessed via constructor DI.
  * Services can be made public within the `Athena::DI::Register` annotation
    * `@[ADI::Register(public: true)]`

## Routing
* Makes controllers structs again
  * Reasoning is a controller is immutable and short lived
  * Also isn't really a use case for having actions on an abstract type
* Support inheriting actions defined on abstract structs
* Uses a `Dequeue` for `RequestStack` since that's essentially what it is
* Updates specs to use `around_all` versus a block wrapping the `describe` block
  * Since how specs are ran changed in `0.31.0`.